### PR TITLE
RHEL based Java S2I builder

### DIFF
--- a/quickstart-templates/rhel-templates.json
+++ b/quickstart-templates/rhel-templates.json
@@ -344,6 +344,340 @@
 					}
 				}
 			]
+		},
+		{
+			"kind": "Template",
+			"apiVersion": "v1",
+			"metadata": {
+				"annotations": {
+					"description": "Java builder and sample application",
+					"iconClass": "icon-openjdk",
+					"tags": "java"
+				},
+				"name": "java-quickstart-rhel"
+			},
+			"labels": {
+				"template": "java-quickstart-rhel"
+			},
+			"parameters": [
+				{
+					"description": "The name for the builder.",
+					"displayName": "Builder name",
+					"name": "BUILDER_NAME",
+					"value": "s2i-java",
+					"required": true
+				},
+				{
+					"description": "Git source URI for the builder",
+					"displayName": "Builder source url",
+					"name": "BUILDER_SOURCE_REPOSITORY_URL",
+					"value": "https://github.com/redhat-cop/containers-quickstarts.git",
+					"required": true
+				},
+				{
+					"description": "Builder source branch/tag reference.",
+					"displayName": "Builder source branch/tag reference.",
+					"name": "BUILDER_SOURCE_REPOSITORY_REF",
+					"value": "master",
+					"required": false
+				},
+				{
+					"description": "Path within Git project to build containing the Java builder; empty for root project directory.",
+					"displayName": "Builder context directory.",
+					"name": "BUILDER_CONTEXT_DIR",
+					"value": "s2i-java",
+					"required": false
+				},
+				{
+					"description": "The name for the application.",
+					"displayName": "Application name",
+					"name": "APPLICATION_NAME",
+					"value": "java-app",
+					"required": true
+				},
+				{
+					"description": "Git source URI for the application",
+					"displayName": "Application source url",
+					"name": "APPLICATION_SOURCE_REPOSITORY_URL",
+					"value": "https://github.com/fabric8-quickstarts/spring-boot-webmvc.git",
+					"required": true
+				},
+				{
+					"description": "Application source branch/tag reference.",
+					"displayName": "Application source branch/tag reference.",
+					"name": "APPLICATION_SOURCE_REPOSITORY_REF",
+					"value": "master",
+					"required": false
+				},
+				{
+					"description": "Path within Git project to build containing the application; empty for root project directory.",
+					"displayName": "Application context directory.",
+					"name": "APPLICATION_CONTEXT_DIR",
+					"value": "",
+					"required": false
+				},
+				{
+					"name": "APPLICATION_HOSTNAME",
+					"displayName": "Application route hostname.",
+					"description": "Custom hostname for the service route.  Leave blank for default hostname, e.g.: \u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+				}
+			],
+			"objects": [
+				{
+					"kind": "ImageStream",
+					"apiVersion": "v1",
+					"metadata": {
+						"name": "rhel7",
+						"labels": {
+							"build": "${BUILDER_NAME}"
+						}
+					},
+					"spec": {
+						"dockerImageRepository": "registry.access.redhat.com/rhel7/rhel"
+					}
+				},
+				{
+					"kind": "ImageStream",
+					"apiVersion": "v1",
+					"metadata": {
+						"name": "${BUILDER_NAME}",
+						"labels": {
+							"build": "${BUILDER_NAME}"
+						}
+					}
+				},
+				{
+					"kind": "ImageStream",
+					"apiVersion": "v1",
+					"metadata": {
+						"name": "${APPLICATION_NAME}",
+						"labels": {
+							"application": "${APPLICATION_NAME}"
+						}
+					}
+				},
+				{
+					"kind": "BuildConfig",
+					"apiVersion": "v1",
+					"metadata": {
+						"name": "${BUILDER_NAME}",
+						"labels": {
+							"build": "${BUILDER_NAME}"
+						}
+					},
+					"spec": {
+						"triggers": [
+							{
+								"type": "ConfigChange"
+							},
+							{
+								"type": "ImageChange",
+								"imageChange": {}
+							}
+						],
+						"source": {
+							"type": "Git",
+							"git": {
+								"uri": "${BUILDER_SOURCE_REPOSITORY_URL}",
+								"ref": "${BUILDER_SOURCE_REPOSITORY_REF}"
+							},
+							"contextDir": "${BUILDER_CONTEXT_DIR}"
+						},
+						"strategy": {
+							"type": "Docker",
+							"dockerStrategy": {
+								"from": {
+									"kind": "ImageStreamTag",
+									"name": "rhel7:7.2"
+								}
+							}
+						},
+						"output": {
+							"to": {
+								"kind": "ImageStreamTag",
+								"name": "${BUILDER_NAME}:latest"
+							}
+						}
+					}
+				},
+				{
+					"kind": "Route",
+					"apiVersion": "v1",
+					"metadata": {
+						"name": "${APPLICATION_NAME}",
+						"labels": {
+							"application": "${APPLICATION_NAME}"
+						},
+						"annotations": {
+							"description": "Route for application's http service."
+						}
+					},
+					"spec": {
+						"host": "${APPLICATION_HOSTNAME}",
+						"to": {
+							"kind": "Service",
+							"name": "${APPLICATION_NAME}"
+						},
+						"port": {
+							"targetPort": "8080-tcp"
+						}
+					}
+				},
+				{
+					"kind": "BuildConfig",
+					"apiVersion": "v1",
+					"metadata": {
+						"name": "${APPLICATION_NAME}",
+						"labels": {
+							"application": "${APPLICATION_NAME}"
+						}
+					},
+					"spec": {
+						"triggers": [
+							{
+								"type": "ConfigChange"
+							},
+							{
+								"type": "ImageChange",
+								"imageChange": {}
+							}
+						],
+						"source": {
+							"type": "Git",
+							"git": {
+								"uri": "${APPLICATION_SOURCE_REPOSITORY_URL}",
+								"ref": "${APPLICATION_SOURCE_REPOSITORY_REF}"
+							},
+							"contextDir": "${APPLICATION_CONTEXT_DIR}"
+						},
+						"strategy": {
+							"type": "Source",
+							"sourceStrategy": {
+								"from": {
+									"kind": "ImageStreamTag",
+									"name": "${BUILDER_NAME}:latest"
+								}
+							}
+						},
+						"output": {
+							"to": {
+								"kind": "ImageStreamTag",
+								"name": "${APPLICATION_NAME}:latest"
+							}
+						}
+					}
+				},
+				{
+					"kind": "Service",
+					"apiVersion": "v1",
+					"metadata": {
+						"name": "${APPLICATION_NAME}",
+						"labels": {
+							"application": "${APPLICATION_NAME}"
+						},
+						"annotations": {
+							"description": "The application server's http port."
+						}
+					},
+					"spec": {
+						"ports": [
+							{
+								"name": "8080-tcp",
+								"protocol": "TCP",
+								"port": 8080,
+								"targetPort": 8080
+							}
+						],
+						"selector": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentconfig": "${APPLICATION_NAME}"
+						},
+						"type": "ClusterIP",
+						"sessionAffinity": "None"
+					}
+				},
+				{
+					"kind": "DeploymentConfig",
+					"apiVersion": "v1",
+					"metadata": {
+						"name": "${APPLICATION_NAME}",
+						"labels": {
+							"app": "${APPLICATION_NAME}"
+						}
+					},
+					"spec": {
+						"strategy": {
+							"type": "Rolling",
+							"rollingParams": {
+								"updatePeriodSeconds": 1,
+								"intervalSeconds": 1,
+								"timeoutSeconds": 600,
+								"maxUnavailable": "25%",
+								"maxSurge": "25%"
+							},
+							"resources": {}
+						},
+						"triggers": [
+							{
+								"type": "ConfigChange"
+							},
+							{
+								"type": "ImageChange",
+								"imageChangeParams": {
+									"automatic": true,
+									"containerNames": [
+										"${APPLICATION_NAME}"
+									],
+									"from": {
+										"kind": "ImageStreamTag",
+										"name": "${APPLICATION_NAME}:latest"
+									}
+								}
+							}
+						],
+						"replicas": 1,
+						"test": false,
+						"selector": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentconfig": "${APPLICATION_NAME}"
+						},
+						"template": {
+							"metadata": {
+								"labels": {
+									"application": "${APPLICATION_NAME}",
+									"deploymentconfig": "${APPLICATION_NAME}"
+								}
+							},
+							"spec": {
+								"containers": [
+									{
+										"name": "${APPLICATION_NAME}",
+										"image": "${APPLICATION_NAME}",
+										"ports": [
+											{
+												"containerPort": 8080,
+												"protocol": "TCP"
+											},
+                                            {
+                                                "name": "jolokia",
+                                                "containerPort": 8778,
+                                                "protocol": "TCP"
+                                            }
+										],
+										"resources": {},
+										"terminationMessagePath": "/dev/termination-log",
+										"imagePullPolicy": "Always"
+									}
+								],
+								"restartPolicy": "Always",
+								"terminationGracePeriodSeconds": 30,
+								"dnsPolicy": "ClusterFirst",
+								"securityContext": {}
+							}
+						}
+					}
+				}
+			]
 		}
 	]
 }

--- a/s2i-java/Dockerfile
+++ b/s2i-java/Dockerfile
@@ -1,0 +1,98 @@
+FROM rhel:7.2
+
+ENV MAVEN_VERSION="3.3.3" \
+    JOLOKIA_VERSION="1.3.5" \
+    PATH=$PATH:"/usr/local/s2i" \
+    AB_JOLOKIA_CONFIG="/opt/jolokia/jolokia.properties" \
+    AB_JOLOKIA_AUTH_OPENSHIFT="true" \
+    JAVA_DATA_DIR=/deployments/data
+
+# Some version information
+LABEL io.k8s.description="Platform for building and running plain Java applications (fat-jar and flat classpath)" \
+      io.k8s.display-name="Java Applications" \
+      io.openshift.tags="builder,java" \
+      io.openshift.s2i.scripts-url="image:///usr/local/s2i" \
+      io.openshift.s2i.destination="/tmp" \
+      io.openshift.expose-services="8080,8778" \
+      org.jboss.deployments-dir="/deployments"
+
+
+# Need to install Yum Base Packages, and Java
+RUN yum repolist > /dev/null && \
+    yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum clean all && \
+    INSTALL_PKGS="autoconf \
+    automake \
+    bsdtar \
+    bzip2 \
+    findutils \
+    gcc-c++ \
+    gd-devel \
+    gdb \
+    gettext \
+    git \
+    libcurl-devel \
+    libxml2-devel \
+    libxslt-devel \
+    lsof \
+    make \
+    openssl-devel \
+    patch \
+    procps-ng \
+    scl-utils \
+    tar \
+    unzip \
+    wget \
+    which \
+    yum-utils \
+    zlib-devel \
+    java-1.8.0-openjdk-devel" && \
+    yum install -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    
+    # Add Java User
+    groupadd -r java -g 1000 && \
+    useradd -u 185 -r -g java -m -d /opt/java -s /sbin/nologin -c "Java user" java && \
+    
+    # Install Maven
+    curl https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
+    tar -xzf - -C /opt && \
+    ln -s /opt/apache-maven-${MAVEN_VERSION} /opt/maven && \
+    ln -s /opt/maven/bin/mvn /usr/bin/mvn && \
+    
+    # Install Jolokia
+    mkdir -p /opt/jolokia && \
+    curl http://central.maven.org/maven2/org/jolokia/jolokia-jvm/${JOLOKIA_VERSION}/jolokia-jvm-${JOLOKIA_VERSION}-agent.jar \
+         -o /opt/jolokia/jolokia.jar
+
+
+ADD jolokia-opts /opt/jolokia/jolokia-opts
+
+RUN chmod 444 /opt/jolokia/jolokia.jar && \
+    chmod 755 /opt/jolokia/jolokia-opts
+
+# Expose Ports
+EXPOSE 8080 8778
+
+ADD jolokia.properties /opt/jolokia.properties
+
+# S2I scripts + README
+COPY s2i /usr/local/s2i
+RUN chmod 755 /usr/local/s2i/*
+ADD README.md /usr/local/s2i/usage.txt
+
+# Add run script as /opt/run-java/run-java.sh and make it executable
+COPY run-java.sh java-container-options run-env.sh /opt/run-java/
+
+RUN chmod 755 /opt/run-java/run-java.sh /opt/run-java/java-container-options /opt/run-java/run-env.sh && \
+ mkdir -p /deployments/data && \
+ chmod -R "g+rwX" /deployments && \
+ chown -R java:root /deployments
+
+# S2I requires a numeric, non-0 UID. This is the UID for the java user in the base image
+USER 185
+
+# Use the run script as default since we are working as an hybrid image which can be
+# used directly to. (If we were a plain s2i image we would print the usage info here)
+CMD [ "/usr/local/s2i/run" ]

--- a/s2i-java/README.md
+++ b/s2i-java/README.md
@@ -1,0 +1,57 @@
+# S2I Java builder image 
+
+*Note: This image is a fork of the Java S2I builder from the [fabric8](https://github.com/fabric8io-images/s2i/tree/master/java/images/rhel) project. A first class supported Java S2I builder will be part of Fuse Integration Services 2.0 (Early 2017).*
+
+This is a S2I builder image for Java builds whose result can be run directly without any further application server.
+It's suited ideally for microservices with a flat classpath (including "far jars").
+
+This image also provides an easy integration with an [Jolokia](https://github.com/rhuss/jolokia)  agent. See below
+how to configure this.
+
+The following environment variables can be used to influence the behavior of this builder image:
+
+## Build Time
+
+* **MAVEN_ARGS** Arguments to use when calling maven, replacing the default `package hawt-app:build -DskipTests -e`. Please be sure to run the `hawt-app:build` goal (when not already bound to the `package` execution phase), otherwise the startup scripts won't work.
+* **MAVEN_ARGS_APPEND** Additional Maven  arguments, useful for temporary adding arguments like `-X` or `-am -pl ..`
+* **ARTIFACT_DIR** Path to `target/` where the jar files are created for multi module builds. These are added to `${MAVEN_ARGS}`
+* **ARTIFACT_COPY_ARGS** Arguments to use when copying artifacts from the output dir to the application dir. Useful to specify which artifacts will be part of the image. It defaults to `-r hawt-app/*` when a `hawt-app` dir is found on the build directory, otherwise jar files only will be included (`*.jar`).
+* **MAVEN_CLEAR_REPO** If set then the Maven repository is removed after the artifact is built. This is useful for keeping
+  the created application image small, but prevents *incremental* builds. The default is `false`
+
+## Run Time
+
+The run script can be influenced by the following environment variables:
+
+* **JAVA_OPTIONS**  Options that will be passed to the JVM.  Use it to set options like the max JVM memory (-Xmx1G).
+* **JAVA_ENABLE_DEBUG**  If set to true, then enables JVM debugging
+* **JAVA_DEBUG_PORT** Port used for debugging (default: 5005)
+* **JAVA_AGENT** Set this to pass any JVM agent arguments for stuff like profilers
+* **JAVA_MAIN_ARGS** Arguments that will be passed to you application's main method.  **Default:** the arguments passed to the `bin/run` script.
+* **JAVA_MAIN_CLASS** The main class to use if not configured within the plugin
+
+The environment variables are best set in `.sti/environment` top in you project. This file is picked up bei S2I
+during building and running.
+
+#### Jolokia configuration
+
+* **AB_JOLOKIA_OFF** : If set disables activation of Joloka (i.e. echos an empty value). By default, Jolokia is enabled.
+* **AB_JOLOKIA_CONFIG** : If set uses this file (including path) as Jolokia JVM agent properties (as described 
+  in Jolokia's [reference manual](http://www.jolokia.org/reference/html/agents.html#agents-jvm)). 
+  By default this is `/opt/jolokia/jolokia.properties`. 
+* **AB_JOLOKIA_HOST** : Host address to bind to (Default: `0.0.0.0`)
+* **AB_JOLOKIA_PORT** : Port to use (Default: `8778`)
+* **AB_JOLOKIA_USER** : User for authentication. By default authentication is switched off.
+* **AB_JOLOKIA_PASSWORD** : Password for authentication. By default authentication is switched off.
+* **AB_JOLOKIA_HTTPS** : Switch on secure communication with https. By default self signed server certificates are generated
+  if no `serverCert` configuration is given in `AB_JOLOKIA_OPTS`
+* **AB_JOLOKIA_ID** : Agent ID to use (`$HOSTNAME` by default, which is the container id)
+* **AB_JOLOKIA_OPTS**  : Additional options to be appended to the agent opts. They should be given in the format 
+  "key=value,key=value,..."
+
+Some options for integration in various environments:
+
+* **AB_JOLOKIA_AUTH_OPENSHIFT** : Switch on client authentication for OpenShift TSL communication. The value of this 
+  parameter can be a relative distinguished name which must be contained in a presented client certificate. Enabling this
+  parameter will automatically switch Jolokia into https communication mode. The default CA cert is set to 
+  `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`

--- a/s2i-java/java-container-options
+++ b/s2i-java/java-container-options
@@ -1,0 +1,47 @@
+#!/bin/sh
+# =================================================================
+# Detect whether running in a container and set appropriate options
+# for limiting Java VM resources
+#
+# Usage: JAVA_OPTIONS="$(java-container-options.sh)"
+
+# Env Vars respected:
+
+# JAVA_OPTIONS: Checked for already set options
+# JAVA_MAX_MEM_RATIO: Ratio use to calculate a default maximum Memory, in percent.
+#                     E.g. the default value "85" implies that 85% of the Memory
+#                     given to the container is used as the maximum heap memory with
+#                     '-Xmx'
+
+# Check for memory options and calculate a sane default if not given
+max_memory() {
+  # High number which is the max limit unti which memory is supposed to be
+  # unbounded. 512 TB for now.
+  local max_mem_unbounded="562949953421312"
+
+  # Check whether -Xmx is already given in JAVA_OPTIONS. Then we dont
+  # do anything here
+  if echo "${JAVA_OPTIONS}" | grep -q -- "-Xmx"; then
+    return
+  fi
+
+  # Check if explicitely disabled
+  if [ "x$JAVA_MAX_MEM_RATIO" = "x0" ]; then
+    return
+  fi
+
+  # Check for the 'real memory size' and caluclate mx from a ratio
+  # given (default is 85%)
+  local mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+  if [ -r "${mem_file}" ]; then
+    local max_mem="$(cat ${mem_file})"
+    local ratio=${JAVA_MAX_MEM_RATIO:-85}
+    if [ ${max_mem} -lt ${max_mem_unbounded} ]; then
+      local mx=$(echo "${max_mem} ${ratio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}')
+      echo "-Xmx${mx}m"
+    fi
+  fi
+}
+
+## Echo options, trimming trailing and multiple spaces
+echo "$(max_memory)" | awk '$1=$1'

--- a/s2i-java/jolokia-opts
+++ b/s2i-java/jolokia-opts
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+dir=${AB_JOLOKIA_DIR:-/opt/jolokia}
+sep="="
+
+# Check whether a given config is contained in AB_JOLOKIA_OPTS
+is_in_jolokia_opts() {
+  local prop=$1
+  if [ -n "${AB_JOLOKIA_OPTS}" ] && [ x"${AB_JOLOKIA_OPTS}" != x"${AB_JOLOKIA_OPTS/${prop}/}" ]; then
+     echo "yes"
+  else
+     echo "no"
+  fi
+}
+
+if [ -z ${AB_JOLOKIA_OFF+x} ]; then
+   opts="-javaagent:$dir/jolokia.jar"
+   config=${AB_JOLOKIA_CONFIG:-$dir/jolokia.properties}
+   if [ -f "$config" ]; then
+      # Configuration takes precedence
+      opts="${opts}${sep}config=${config}"
+      sep=","
+      grep -q -e '^host' ${config} && host_in_config=1
+   fi
+   if [ -z ${AB_JOLOKIA_HOST+x} ] && [ -z ${host_in_config+x} ]; then
+      AB_JOLOKIA_HOST='0.0.0.0'
+   fi
+   if [ -n "$AB_JOLOKIA_HOST" ]; then
+      opts="${opts}${sep}host=${AB_JOLOKIA_HOST}"
+      sep=","
+   fi
+   if [ -n "$AB_JOLOKIA_PORT" ]; then
+      opts="${opts}${sep}port=${AB_JOLOKIA_PORT}"
+      sep=","
+   fi
+   if [ -n "$AB_JOLOKIA_USER" ]; then
+      opts="${opts}${sep}user=${AB_JOLOKIA_USER}"
+      sep=","
+   fi
+   if [ -n "$AB_JOLOKIA_PASSWORD" ]; then
+      opts="${opts}${sep}password=${AB_JOLOKIA_PASSWORD}"
+      sep=","
+   fi
+   if [ -n "$AB_JOLOKIA_HTTPS" ]; then
+      opts="${opts}${sep}protocol=https"
+      use_https=1
+      sep=","
+   fi
+   # Integration with OpenShift client cert auth is enabled
+   # by default if not explicitly turned off by setting to 'false'
+   if [ "x${AB_JOLOKIA_AUTH_OPENSHIFT}" != "xfalse" ] && [ -f "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" ]; then
+      auth_opts="useSslClientAuthentication=true,extraClientCheck=true"
+      if [ -z ${use_https+x} ]; then
+        auth_opts="${auth_opts},protocol=https"
+      fi
+      if [ $(is_in_jolokia_opts "caCert") != "yes" ]; then
+         auth_opts="${auth_opts},caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      fi
+      if [ $(is_in_jolokia_opts "clientPrincipal") != "yes" ]; then
+         if [  x"${AB_JOLOKIA_AUTH_OPENSHIFT}" != x"${AB_JOLOKIA_AUTH_OPENSHIFT/=/}" ]; then
+            # Supposed to contain a principal name to check
+            auth_opts="${auth_opts},clientPrincipal=`echo ${AB_JOLOKIA_AUTH_OPENSHIFT} | sed -e 's/ /\\\\ /g'`"
+         else
+            auth_opts="${auth_opts},clientPrincipal=cn=system:master-proxy"
+         fi
+      fi
+      opts="${opts}${sep}${auth_opts}"
+      sep=","
+   fi
+   # Add extra opts to the end
+   if [ -n "${AB_JOLOKIA_OPTS}" ]; then
+      opts="${opts}${sep}${AB_JOLOKIA_OPTS}"
+      sep=","
+   fi
+   if [ "x$sep" != 'x=' ] ; then
+     echo ${opts}
+   fi
+fi

--- a/s2i-java/jolokia.properties
+++ b/s2i-java/jolokia.properties
@@ -1,0 +1,3 @@
+host=*
+port=8778
+discoveryEnabled=false

--- a/s2i-java/run-env.sh
+++ b/s2i-java/run-env.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Set the application dir to the S2I deployment dir
+JAVA_APP_DIR=/deployments

--- a/s2i-java/run-java.sh
+++ b/s2i-java/run-java.sh
@@ -1,0 +1,231 @@
+#!/bin/sh
+
+# ==========================================================
+# Generic run script for running arbitrary Java applications
+#
+# Source and Documentation can be found
+# at https://github.com/fabric8io/run-java-sh
+#
+# ==========================================================
+
+# Error is indicated with a prefix in the return value
+check_error() {
+  local msg=$1
+  if echo ${msg} | grep -q "^ERROR:"; then
+    echo ${msg}
+    exit 1
+  fi
+}
+
+# The full qualified directory where this script is located
+get_script_dir() {
+  # Default is current directory
+  local dir=`dirname "$0"`
+  local full_dir=`cd "${dir}" ; pwd`
+  echo ${full_dir}
+}
+
+# Try hard to find a sane default jar-file
+auto_detect_jar_file() {
+  local dir=$1
+
+  # Filter out temporary jars from the shade plugin which start with 'original-'
+  local old_dir=$(pwd)
+  cd ${dir}
+  if [ $? = 0 ]; then
+    local nr_jars=`ls *.jar 2>/dev/null | grep -v '^original-' | wc -l | tr -d '[[:space:]]'`
+    if [ ${nr_jars} = 1 ]; then
+      ls *.jar | grep -v '^original-'
+      exit 0
+    fi
+    cd ${old_dir}
+    echo "ERROR: Neither \$JAVA_MAIN_CLASS nor \$JAVA_APP_JAR is set and ${nr_jars} found in ${dir} (1 expected)"
+  else
+    echo "ERROR: No directory ${dir} found for auto detection"
+  fi
+}
+
+# Check directories (arg 2...n) for a jar file (arg 1)
+get_jar_file() {
+  local jar=$1
+  shift;
+
+  if [ "${jar:0:1}" = "/" ]; then
+    if [ -f "${jar}" ]; then
+      echo "${jar}"
+    else
+      echo "ERROR: No such file ${jar}"
+    fi
+  else
+    for dir in $*; do
+      if [ -f "${dir}/$jar" ]; then
+        echo "${dir}/$jar"
+        return
+      fi
+    done
+    echo "ERROR: No ${jar} found in $*"
+  fi
+}
+
+load_env() {
+  local script_dir=$1
+
+  # Configuration stuff is read from this file
+  local run_env_sh="run-env.sh"
+
+  # Load default default config
+  if [ -f "${script_dir}/${run_env_sh}" ]; then
+    source "${script_dir}/${run_env_sh}"
+  fi
+
+  # Check also $JAVA_APP_DIR. Overrides other defaults
+  # It's valid to set the app dir in the default script
+  if [ -z "${JAVA_APP_DIR}" ]; then
+    JAVA_APP_DIR="${script_dir}"
+  else
+    if [ -f "${JAVA_APP_DIR}/${run_env_sh}" ]; then
+      source "${JAVA_APP_DIR}/${run_env_sh}"
+    fi
+  fi
+  export JAVA_APP_DIR
+
+  # JAVA_LIB_DIR defaults to JAVA_APP_DIR
+  export JAVA_LIB_DIR="${JAVA_LIB_DIR:-${JAVA_APP_DIR}}"
+  if [ -z "${JAVA_MAIN_CLASS}" ] && [ -z "${JAVA_APP_JAR}" ]; then
+    JAVA_APP_JAR="$(auto_detect_jar_file ${JAVA_APP_DIR})"
+    check_error "${JAVA_APP_JAR}"
+  fi
+  if [ "x${JAVA_APP_JAR}" != x ]; then
+    local jar="$(get_jar_file ${JAVA_APP_JAR} ${JAVA_APP_DIR} ${JAVA_LIB_DIR})"
+    check_error "${jar}"
+    export JAVA_APP_JAR=${jar}
+  else
+    export JAVA_MAIN_CLASS
+  fi
+}
+
+# Check for stanarad-opts first, fallback to run-java-options in the path if not existing
+run_java_options() {
+  if [ -f "/opt/run-java-options" ]; then
+    echo `sh /opt/run-java-options`
+  else
+    which run-java-options >/dev/null 2>&1
+    if [ $? = 0 ]; then
+      echo `run-java-options`
+    fi
+  fi
+}
+
+# Echo the proper options to switch on debugging
+debug_options() {
+  if [ "x${JAVA_ENABLE_DEBUG}" != "x" ]; then
+    local debug_port=${JAVA_DEBUG_PORT:-5005}
+    echo "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${debug_port}"
+  fi
+}
+
+# Combine all java options
+get_java_options() {
+  local script=$(readlink -f "$0")
+  local dir=$(dirname "$script")
+  kcontainer_java_opts=""
+  if [ -f "$dir/java-container-options" ]; then
+    container_java_opts=$($dir/java-container-options)
+  fi
+  # Normalize spaces (i.e. trim and elimate double spaces)
+  echo "${JAVA_OPTIONS} $(debug_options) $(run_java_options) ${container_java_opts}" | awk '$1=$1'
+}
+
+# Read in a classpath either from a file with a single line, colon separated
+# or given line-by-line in separate lines
+# Arg 1: path to claspath (must exist), optional arg2: application jar, which is stripped from the classpath in
+# multi line arrangements
+format_classpath() {
+  local cp_file="$1"
+  local app_jar="$2"
+
+  local wc_out=`wc -l $1 2>&1`
+  if [ $? -ne 0 ]; then
+    echo "Cannot read lines in ${cp_file}: $wc_out"
+    exit 1
+  fi
+
+  local nr_lines=`echo $wc_out | awk '{ print $1 }'`
+  if [ ${nr_lines} -gt 1 ]; then
+    local sep=""
+    local classpath=""
+    while read file; do
+      local full_path="${JAVA_LIB_DIR}/${file}"
+      # Don't include app jar if include in list
+      if [ x"${app_jar}" != x"${full_path}" ]; then
+        classpath="${classpath}${sep}${full_path}"
+      fi
+      sep=":"
+    done < "${cp_file}"
+    echo "${classpath}"
+  else
+    # Supposed to be a single line, colon separated classpath file
+    cat "${cp_file}"
+  fi
+}
+
+# Fetch classpath from env or from a local "run-classpath" file
+get_classpath() {
+  local cp_path="."
+  if [ "x${JAVA_LIB_DIR}" != "x${JAVA_APP_DIR}" ]; then
+    cp_path="${cp_path}:${JAVA_LIB_DIR}"
+  fi
+  if [ -z "${JAVA_CLASSPATH}" ] && [ "x${JAVA_MAIN_CLASS}" != x ]; then
+    if [ "x${JAVA_APP_JAR}" != x ]; then
+      cp_path="${cp_path}:${JAVA_APP_JAR}"
+    fi
+    if [ -f "${JAVA_LIB_DIR}/classpath" ]; then
+      # Classpath is pre-created and stored in a 'run-classpath' file
+      cp_path="${cp_path}:`format_classpath ${JAVA_LIB_DIR}/classpath ${JAVA_APP_JAR}`"
+    else
+      # No order implied
+      cp_path="${cp_path}:${JAVA_APP_DIR}/*"
+    fi
+  elif [ "x${JAVA_CLASSPATH}" != x ]; then
+    # Given from the outside
+    cp_path="${JAVA_CLASSPATH}"
+  fi
+  echo "${cp_path}"
+}
+
+# Set process name if possible
+get_exec_args() {
+  EXEC_ARGS=""
+  if [ "x${JAVA_APP_NAME}" != x ]; then
+    # Not all shells support the 'exec -a newname' syntax..
+    `exec -a test true 2>/dev/null`
+    if [ "$?" = 0 ] ; then
+      echo "-a '${JAVA_APP_NAME}'"
+    else
+      # Lets switch to bash if you have it installed...
+      if [ -f "/bin/bash" ] ; then
+        exec "/bin/bash" $0 $@
+      fi
+    fi
+  fi
+}
+
+# Start JVM
+startup() {
+  # Initialize environment
+  load_env $(get_script_dir)
+
+  local args
+  cd ${JAVA_APP_DIR}
+  if [ "x${JAVA_MAIN_CLASS}" != x ] ; then
+     args="${JAVA_MAIN_CLASS}"
+  else
+     args="-jar ${JAVA_APP_JAR}"
+  fi
+  echo exec $(get_exec_args) java $(get_java_options) -cp "$(get_classpath)" ${args} $*
+  exec $(get_exec_args) java $(get_java_options) -cp "$(get_classpath)" ${args} $*
+}
+
+# =============================================================================
+# Fire up
+startup $*

--- a/s2i-java/s2i/assemble
+++ b/s2i-java/s2i/assemble
@@ -1,0 +1,157 @@
+#!/bin/sh
+# Global S2I variable setup
+source `dirname "$0"`/s2i-setup
+
+# Maven arguments setting up the environment
+maven_env_args="-Dmaven.repo.local=${S2I_ARTIFACTS_DIR}/m2"
+
+# =========================================================================
+# Helper functions:
+
+function check_error() {
+  local label=$1
+  local error=$2
+  if [ ${error} -ne 0 ]; then
+    echo "Aborting due to error code $error for $label"
+    exit ${error}
+  fi
+}
+
+function get_output_dir() {
+  local dir=""
+
+  # If multi module build and no ARTIFACT_DIR is set --> error
+  if [ x"${ARTIFACT_DIR}" = x ]; then
+    echo " ${MAVEN_ARGS} ${MAVEN_ARGS_APPEND}" | grep -q ' -pl'
+    if [ $? -eq 0 ]; then
+       echo "ARTIFACT_DIR must be set for multi module Maven builds"
+       exit 1
+    fi
+    dir="${S2I_SOURCE_DIR}/target"
+  else
+    if [ "${ARTIFACT_DIR:0:1}" = "/" ]; then
+       echo "ARTIFACT_DIR \"${ARTIFACT_DIR}\" must not be absolute but relative to the source directory"
+       exit 1
+    fi
+    dir="${S2I_SOURCE_DIR}/${ARTIFACT_DIR}"
+  fi
+
+  # Normalize dir
+  dir=$(echo ${dir} | tr -s /)
+  dir=${dir%/}
+  # The parent must exist but target/ won't exist yet
+  if [ ! -d $(dirname "${dir}"}) ]; then
+    echo "Please specify an existing build directory ARTIFACT_DIR (tried '$(dirname "${dir}")' which does not exist)"
+    exit 1
+  fi
+  echo ${dir}
+}
+
+function copy_dir() {
+  local src=$1
+  local dest=$2
+  
+  # Copy recursively and preserve ownership: -a
+  cp -a ${src}/* ${dest}
+}
+
+function copy_artifacts() {
+    local dir=$1
+    local dest=$2
+
+    cd ${dir}
+
+    local cp_args=${ARTIFACT_COPY_ARGS}
+    if [ x"${cp_args}" = x ]; then
+        if [ -d "hawt-app" ]; then
+            cp_args="-r hawt-app/*"
+        else
+            cp_args="*.jar"
+        fi
+    fi
+    echo "Running: cp ${cp_args} ${dest}"
+    cp ${cp_args} ${dest}
+}
+
+function setup_maven() {
+  if [ -f "${S2I_SOURCE_DIR}/configuration/settings.xml" ]; then
+    maven_env_args="${maven_env_args} -s ${S2I_SOURCE_DIR}/configuration/settings.xml"
+    echo "Using custom maven settings from ${S2I_SOURCE_DIR}/configuration/settings.xml"
+  fi
+}
+
+function build_maven() {
+  # Where artifacts are created during build
+  local build_dir=$1
+
+  # Where to put the artifacts
+  local app_dir=$2
+
+  # Default args: no tests, if a module is specified, only build this module
+  local maven_args=${MAVEN_ARGS:-package -DskipTests -e}
+
+  echo "Found pom.xml ... "
+  echo "Running 'mvn ${maven_env_args} ${maven_args} ${MAVEN_ARGS_APPEND}'"
+
+  local old_dir=$(pwd)
+  cd ${S2I_SOURCE_DIR}
+  check_error "changing directory to ${S2I_SOURCE_DIR}" $?
+
+  # =========
+  # Run Maven
+  mvn ${maven_env_args} --version
+  mvn ${maven_env_args} ${maven_args} ${MAVEN_ARGS_APPEND}
+  check_error "Maven build" $?
+
+  # ==============
+  # Copy artifacts
+  echo "Copying Maven artifacts from ${build_dir} to ${app_dir} ..."
+  copy_artifacts ${build_dir} ${app_dir}
+  check_error "copying artifacts from ${build_dir} to ${app_dir}" $?
+
+  # ======================
+  # ======================
+  # Remove repo if desired
+  if [ "x${MAVEN_CLEAR_REPO}" != "x" ]; then
+    rm -rf "${S2I_ARTIFACTS_DIR}/m2"
+    check_error "Cannot remove local Maven repository ${S2I_ARTIFACTS_DIR}/m2" $?
+  fi
+
+  cd ${old_dir}
+}
+
+# =========================================================================
+# Main
+
+echo "=================================================================="
+echo "Starting S2I Java Build ....."
+build_dir=$(get_output_dir)
+check_error "Cannot get output dir: $build_dir" $?
+if [ -f "${S2I_SOURCE_DIR}/pom.xml" ]; then
+  echo "Maven build detected"
+  # If a pom.xml is present use maven
+  setup_maven
+  build_maven ${build_dir} ${DEPLOYMENTS_DIR}
+elif [ -f "${S2I_SOURCE_DIR}/Dockerfile" ] && [ -d "${S2I_SOURCE_DIR}/maven" ]; then
+  # This is a binary build.
+  echo "S2I binary build detected"
+  binary_dir="${S2I_SOURCE_DIR}/maven"
+  echo "Copying binaries from ${binary_dir} to ${DEPLOYMENTS_DIR} ..."
+  copy_dir ${binary_dir} ${DEPLOYMENTS_DIR}
+  check_error "copying ${binary_dir} to ${DEPLOYMENTS_DIR}" $?  
+elif [ -d "${S2I_SOURCE_DIR}" ] && [ `ls -1 | grep "^.*.jar$" | wc -l` -eq 1 ]; then
+  # This is a streamed binary build.
+  echo "S2I streamed binary build detected"
+  binary_dir="${S2I_SOURCE_DIR}"
+  echo "Copying streamed binaries from ${binary_dir} to ${DEPLOYMENTS_DIR} ..."
+  copy_dir ${binary_dir} ${DEPLOYMENTS_DIR}
+  check_error "copying ${binary_dir} to ${DEPLOYMENTS_DIR}" $?
+else
+  binary_dir="${ARTIFACT_DIR:-${S2I_SOURCE_DIR}/deployments}"
+  # Assuming that the source already contains compiled artefacts
+  echo "Copying binaries from ${binary_dir} to ${DEPLOYMENTS_DIR} ..."
+  copy_dir ${binary_dir} ${DEPLOYMENTS_DIR}
+  check_error "copying ${binary_dir} to ${DEPLOYMENTS_DIR}" $?
+fi
+
+echo "... done"

--- a/s2i-java/s2i/run
+++ b/s2i-java/s2i/run
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Global S2I variable setup
+source `dirname "$0"`/s2i-setup
+
+# Setup Jolokia to accept basic auth, using a randomly generated password that is stored
+# in the container in the ${DEPLOYMENTS_DIR}/jolokia.pw file.
+AB_JOLOKIA_USER="jolokia"
+if [ -f "${DEPLOYMENTS_DIR}/jolokia.pw" ] ; then
+	AB_JOLOKIA_PASSWORD=`cat "${DEPLOYMENTS_DIR}/jolokia.pw"`
+else
+	AB_JOLOKIA_PASSWORD=`tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1`
+	touch "${DEPLOYMENTS_DIR}/jolokia.pw"
+	chmod 600 "${DEPLOYMENTS_DIR}/jolokia.pw"
+	echo $AB_JOLOKIA_PASSWORD > "${DEPLOYMENTS_DIR}/jolokia.pw"
+fi
+export AB_JOLOKIA_USER
+export AB_JOLOKIA_PASSWORD
+
+# Always include jolokia-opts, which can be empty if switched off via env
+JAVA_OPTIONS="${JAVA_OPTIONS:+${JAVA_OPTIONS} }$(/opt/jolokia/jolokia-opts)"
+
+# Temporary options variable until the harmonization hawt-app PR #5 has been applied (hopefully)
+JVM_ARGS="${JVM_ARGS:+${JVM_ARGS} }${JAVA_OPTIONS}"
+export JAVA_OPTIONS JVM_ARGS
+
+if [ -f "${DEPLOYMENTS_DIR}/bin/run.sh" ]; then
+    echo "Starting the application using the bundled ${DEPLOYMENTS_DIR}/bin/run.sh ..."
+    exec ${DEPLOYMENTS_DIR}/bin/run.sh
+else
+    echo "Starting the Java application using /opt/run-java/run-java.sh ..."
+    exec /opt/run-java/run-java.sh
+fi

--- a/s2i-java/s2i/s2i-setup
+++ b/s2i-java/s2i/s2i-setup
@@ -1,0 +1,5 @@
+# Local vars setup with defaults
+S2I_DESTINATION=${S2I_DESTINATION:-/tmp}
+S2I_SOURCE_DIR="${S2I_DESTINATION}/src"
+S2I_ARTIFACTS_DIR="${S2I_DESTINATION}/artifacts"
+DEPLOYMENTS_DIR="/deployments"

--- a/s2i-java/s2i/save-artifacts
+++ b/s2i-java/s2i/save-artifacts
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+. `dirname "$0"`/s2i-setup
+
+# Tar up maven repository for reuse in an incremental build
+if [ -d "${S2I_ARTIFACTS_DIR}/m2" ]; then
+   cd ${S2I_ARTIFACTS_DIR}
+   tar cf - m2
+   cd -
+fi

--- a/s2i-java/s2i/usage
+++ b/s2i-java/s2i/usage
@@ -1,0 +1,2 @@
+#!/bin/sh
+cat $(dirname $0)/usage.txt


### PR DESCRIPTION
#### What does this PR do?
Adds RHEL based Java S2I builder

#### How should this be manually tested?

Login to an OpenShift environment and create a new or use an existing project

Build the S2I image

`oc new-build https://github.com/sabre1041/containers-quickstarts#s2i-java --docker-image=registry.access.redhat.com/rhel:7.2 --context-dir=s2i-java --name=s2i-java --strategy=docker`

Once the build completes successfully, deploy a sample application

`oc new-app s2i-java~https://github.com/christian-posta/springboot-f8-demo --name=s2i-java-app`

Verify the build completes successfully and the application is deployed.

Expose the *s2i-java-app* so that is externally accessible

`oc expose svc s2i-java-app`

Locate the hostname of the route that was created

`oc get route s2i-java-app --template='{{ .spec.host }}'`

Navigate to the following URL to confirm functionality

`http://<hostname>/api/hello/test`

A JSON response similar to the following should be returned

```
{"response":"hello","count":0,"your-name":"test"}
```

#### Is there a relevant Issue open for this?
https://trello.com/c/dXlPwQWI

#### Who would you like to review this?
/cc @etsauer  @raffaelespazzoli 