### PR TITLE
Image management jenkins slave

### DIFF
--- a/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
@@ -1,0 +1,23 @@
+FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7
+
+MAINTAINER Andrew Block <ablock@redhat.com>
+
+LABEL com.redhat.component="jenkins-slave-image-mgmt" \
+      name="jenkins-slave-image-mgmt" \
+      architecture="x86_64" \
+      io.k8s.display-name="Jenkins Slave Image Management" \
+      io.k8s.description="Image management tools on top of the jenkins slave base image" \
+      io.openshift.tags="openshift,jenkins,slave,copy"
+
+ENV SKOPEO_BIN=https://github.com/sabre1041/ocp-support-resources/blob/master/skopeo/bin/skopeo?raw=true
+
+USER root
+
+COPY etc/policy.json /etc/containers/
+
+RUN curl -L -o /usr/bin/skopeo $SKOPEO_BIN && \
+    chmod +x /usr/bin/skopeo && \
+    chown -R 1001:0 /etc/containers $HOME /usr/bin/skopeo  && \
+    chmod -R g+rw /etc/containers $HOME /usr/bin/skopeo
+
+USER 1001

--- a/jenkins-slaves/jenkins-slave-image-mgmt/README.md
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/README.md
@@ -1,0 +1,57 @@
+Jenkins Slave for Container and Image Management
+=============================
+
+Jenkins [Slave](https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds) that enables various container and image management capabilities and is optimized for deployment to a Jenkins instance running in the OpenShift Container Platform.
+
+## Primary Components
+
+[Skopeo](https://github.com/projectatomic/skopeo/) - A command utility for various operations on container images and image repositories.
+
+
+## Instantiate Template
+
+A [template](../templates/jenkins-slave-image-mgmt-template.json) is available providing the necessary OpenShift components to build and make the slave image available to be referenced by Jenkins.
+
+Execute the following command to instantiate the template:
+
+```
+oc process -f ../templates/jenkins-slave-image-mgmt-template.json | oc create -f-
+```
+
+A new image build will be started automatically
+
+## Use within Jenkins
+
+The template contains an *ImageStream* that has been configured with the appropriate labels that will be picked up by newly deployed Jenkins instances. 
+
+For existing Jenkins servers, the slave can be added by using the following steps.
+
+1. Login to Jenkins
+2. Click on **Manage Jenkins** and then **Configure System**
+3. Under the *Cloud* section, locate the *Kubernetes* Plugin. Click the *Add Pod Template* dropdown and select **
+4. Enter the following details
+	1. Name: jenkins-slave-image-mgmt
+	2. Labels: jenkins-slave-image-mgmt 
+	3. Docker image
+		1. Using the `oc` command line, run `oc get is jenkins-slave-image-mgmt --template='{{ .status.dockerImageRepository }}`. A value similar to *172.30.186.87:5000/jenkins/jenkins-slave-image-mgmt* should be used
+	4. Jenkins slave root directory: `/tmp`
+5. Click **Save** to apply the changes
+	
+
+## Use within Jenkins Pipeline Script
+
+The following provides an example of how to make use of the image within a Jenkins [pipeline](https://jenkins.io/doc/book/pipeline/) script to execute the *inspect* function of the *skopeo* command line tool:
+
+```
+node('jenkins-slave-image-mgmt') { 
+
+  stage('Inspect Image') {
+    sh """
+
+    set +x
+        
+    skopeo inspect docker://docker.io/fedora
+
+    """
+  }
+```

--- a/jenkins-slaves/jenkins-slave-image-mgmt/etc/policy.json
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/etc/policy.json
@@ -1,0 +1,14 @@
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ],
+    "transports":
+        {
+            "docker-daemon":
+                {
+                    "": [{"type":"insecureAcceptAnything"}]
+                }
+        }
+}

--- a/jenkins-slaves/templates/jenkins-slave-image-mgmt-template.json
+++ b/jenkins-slaves/templates/jenkins-slave-image-mgmt-template.json
@@ -1,0 +1,110 @@
+{
+    "kind": "Template",
+    "apiVersion": "v1",
+    "metadata": {
+        "annotations": {
+            "description": "Zeppelin RHEL application template.",
+            "iconClass": "icon-java",
+            "tags": "java"
+        },
+        "name": "jenkins-slave-image-mgmt"
+    },
+    "labels": {
+        "template": "jenkins-slave-image-mgmt"
+    },
+    "parameters": [
+        {
+            "description": "The name for the Jenkins slave.",
+            "name": "JENKINS_SLAVE_NAME",
+            "value": "jenkins-slave-image-mgmt",
+            "required": true
+        },
+        {
+            "description": "Git source URI for application",
+            "name": "SOURCE_REPOSITORY_URL",
+            "value": "https://github.com/redhat-cop/containers-quickstarts.git",
+            "required": true
+        },
+        {
+            "description": "Git branch/tag reference",
+            "name": "SOURCE_REPOSITORY_REF",
+            "value": "master",
+            "required": false
+        },
+        {
+            "description": "Path within Git project to build; empty for root project directory.",
+            "name": "CONTEXT_DIR",
+            "value": "jenkins-slaves/jenkins-slave-image-mgmt",
+            "required": false
+        }
+    ],
+    "objects": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "jenkins-slave-base-rhel7"
+            },
+            "spec": {
+                "dockerImageRepository": "registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7"
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${JENKINS_SLAVE_NAME}",
+                "labels": {
+                    "role": "jenkins-slave"
+                },
+                "annotations": {
+                    "slave-label": "${JENKINS_SLAVE_NAME}"
+                }
+            }
+        },
+        {
+            "kind": "BuildConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${JENKINS_SLAVE_NAME}",
+                "labels": {
+                    "build": "${JENKINS_SLAVE_NAME}"
+                }
+            },
+            "spec": {
+                "runPolicy": "Serial",
+                "source": {
+                    "type": "Git",
+                    "git": {
+                        "uri": "${SOURCE_REPOSITORY_URL}",
+                        "ref": "${SOURCE_REPOSITORY_REF}"
+                    },
+                    "contextDir": "${CONTEXT_DIR}"
+                },
+                "strategy": {
+                    "type": "Docker",
+                    "dockerStrategy": {
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "jenkins-slave-base-rhel7:latest"
+                        }
+                    }
+                },
+                "output": {
+                    "to": {
+                        "kind": "ImageStreamTag",
+                        "name": "${JENKINS_SLAVE_NAME}:latest"
+                    }
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChange": {}
+                    }
+                ],
+                "resources": {},
+                "postCommit": {}
+            }
+        }
+    ]
+}

--- a/jenkins-slaves/templates/jenkins-slave-image-mgmt-template.json
+++ b/jenkins-slaves/templates/jenkins-slave-image-mgmt-template.json
@@ -3,9 +3,9 @@
     "apiVersion": "v1",
     "metadata": {
         "annotations": {
-            "description": "Zeppelin RHEL application template.",
-            "iconClass": "icon-java",
-            "tags": "java"
+            "description": "Jenkins Image Management Slave Template.",
+            "iconClass": "icon-jenkins",
+            "tags": "jenkins,slave"
         },
         "name": "jenkins-slave-image-mgmt"
     },


### PR DESCRIPTION
#### What is this PR About?
Adds a Jenkins slave image to perform image management (promotions using [skopeo](https://github.com/projectatomic/skopeo/))

#### How do we test this?
A template has been provided to automate the building process

Execute the following from within the *jenkins-slaves/templates* folder to instantiate the template to create the requisite imagestreams and buildconfig

```
oc process -v=SOURCE_REPOSITORY_URL=https://github.com/sabre1041/containers-quickstarts.git,SOURCE_REPOSITORY_REF=jenkins-slave-image-mgmt -f jenkins-slave-image-mgmt-template.json | oc create -f-
```

cc: @redhat-cop/containerize-it @etsauer 
