### PR TITLE
Add jenkins-slave-ansible-stacks

### DIFF
--- a/jenkins-slaves/jenkins-slave-ansible-stacks/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-ansible-stacks/Dockerfile
@@ -11,11 +11,10 @@ LABEL com.redhat.component="jenkins-slave-ansible-stacks" \
 
 USER root
 
-RUN yum --enablerepo rhel-7-server-ose-3.3-rpms install -y \
+RUN yum --enablerepo ${ANSIBLE_YUM_REPO} install -y \
       ansible \
-      atomic-openshift-clients \
-      git && \
     yum clean all && \
-    git clone https://github.com/rht-labs/ansible-stacks.git /opt/ansible-stacks
+    git clone ${ANSIBLE_STACKS_SOURCE_REPOSITORY_URL} /opt/ansible-stacks && \
+    git checkout ${ANSIBLE_STACKS_SOURCE_REPOSITORY_REF}
 
 USER 1001

--- a/jenkins-slaves/jenkins-slave-ansible-stacks/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-ansible-stacks/Dockerfile
@@ -15,6 +15,7 @@ RUN yum --enablerepo ${ANSIBLE_YUM_REPO} install -y \
       ansible \
     yum clean all && \
     git clone ${ANSIBLE_STACKS_SOURCE_REPOSITORY_URL} /opt/ansible-stacks && \
+    cd /opt/ansible-stacks && \
     git checkout ${ANSIBLE_STACKS_SOURCE_REPOSITORY_REF}
 
 USER 1001

--- a/jenkins-slaves/jenkins-slave-ansible-stacks/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-ansible-stacks/Dockerfile
@@ -1,0 +1,21 @@
+FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7
+
+MAINTAINER Johnathan Kupferer <jkupfere@redhat.com>
+
+LABEL com.redhat.component="jenkins-slave-ansible-stacks" \
+      name="jenkins-slave-ansible-stacks" \
+      architecture="x86_64" \
+      io.k8s.display-name="Jenkins Slave Ansible Stacks" \
+      io.k8s.description="Ansible and ansible-stacks on top of the jenkins slave base image" \
+      io.openshift.tags="openshift,jenkins,slave,copy"
+
+USER root
+
+RUN yum --enablerepo rhel-7-server-ose-3.3-rpms install -y \
+      ansible \
+      atomic-openshift-clients \
+      git && \
+    yum clean all && \
+    git clone https://github.com/rht-labs/ansible-stacks.git /opt/ansible-stacks
+
+USER 1001

--- a/jenkins-slaves/jenkins-slave-ansible-stacks/README.md
+++ b/jenkins-slaves/jenkins-slave-ansible-stacks/README.md
@@ -1,0 +1,63 @@
+Jenkins Slave for Ansible Stacks
+=============================
+
+Jenkins [Slave](https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds) that enables various container and image management capabilities and is optimized for deployment to a Jenkins instance running in the OpenShift Container Platform.
+
+## Primary Components
+
+[ansible-stacks](https://github.com/rht-labs/ansible-stacks) - Ansible playbook and roles used to create stacks via push button infrastructure (PBI)
+
+## Instantiate Template
+
+A [template](../templates/jenkins-slave-ansible-stacks-template.json) is available providing the necessary OpenShift components to build and make the slave image available to be referenced by Jenkins.
+
+Execute the following command to instantiate the template:
+
+```
+oc process -f ../templates/jenkins-slave-ansible-stacks-template.json | oc create -f-
+```
+
+A new image build will be started automatically
+
+## Use within Jenkins
+
+The template contains an *ImageStream* that has been configured with the appropriate labels that will be picked up by newly deployed Jenkins instances.
+
+For existing Jenkins servers, the slave can be added by using the following steps.
+
+1. Login to Jenkins
+2. Click on **Manage Jenkins** and then **Configure System**
+3. Under the *Cloud* section, locate the *Kubernetes* Plugin. Click the *Add Pod Template* dropdown and select **
+4. Enter the following details
+	1. Name: jenkins-slave-ansible-stacks
+	2. Labels: jenkins-slave-ansible-stacks
+	3. Docker image
+		1. Using the `oc` command line, run `oc get is jenkins-slave-ansible-stacks --template='{{ .status.dockerImageRepository }}`. A value similar to *172.30.186.87:5000/jenkins/jenkins-slave-ansible-stacks* should be used
+	4. Jenkins slave root directory: `/tmp`
+5. Click **Save** to apply the changes
+	
+
+## Use within Jenkins Pipeline Script
+
+The following provides an example of how to make use of the image within a Jenkins [pipeline](https://jenkins.io/doc/book/pipeline/) script to execute an ansible run using the `local-file.yml` ansible-stacks playbook:
+
+```
+node('jenkins-slave-ansible-stacks') { 
+
+  stage('Create Project') {
+    sh """
+set +x
+cat >/tmp/stacks.yml <<EOF
+openshift_clusters:
+- openshift_host_env: master.openshift.example.com
+  openshift_resources:
+    projects:
+    - name: example
+      display_name: Ansible Stacks Example
+      environment_type: build
+EOF
+
+ansible-playbook /opt/ansible-stacks/playbooks/local-file.yaml -e resource_file=/tmp/stacks.yml -e oc_login="no"
+    """
+  }
+```

--- a/jenkins-slaves/templates/jenkins-slave-ansible-stacks-template.json
+++ b/jenkins-slaves/templates/jenkins-slave-ansible-stacks-template.json
@@ -1,0 +1,110 @@
+{
+    "kind": "Template",
+    "apiVersion": "v1",
+    "metadata": {
+        "annotations": {
+            "description": "Jenkins Ansible Stacks Slave Template.",
+            "iconClass": "icon-jenkins",
+            "tags": "jenkins,slave"
+        },
+        "name": "jenkins-slave-ansible-stacks"
+    },
+    "labels": {
+        "template": "jenkins-slave-ansible-stacks"
+    },
+    "parameters": [
+        {
+            "description": "The name for the Jenkins slave.",
+            "name": "JENKINS_SLAVE_NAME",
+            "value": "jenkins-slave-ansible-stacks",
+            "required": true
+        },
+        {
+            "description": "Git source URI for application",
+            "name": "SOURCE_REPOSITORY_URL",
+            "value": "https://github.com/redhat-cop/containers-quickstarts.git",
+            "required": true
+        },
+        {
+            "description": "Git branch/tag reference",
+            "name": "SOURCE_REPOSITORY_REF",
+            "value": "master",
+            "required": false
+        },
+        {
+            "description": "Path within Git project to build; empty for root project directory.",
+            "name": "CONTEXT_DIR",
+            "value": "jenkins-slaves/jenkins-slave-ansible-stacks",
+            "required": false
+        }
+    ],
+    "objects": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "jenkins-slave-base-rhel7"
+            },
+            "spec": {
+                "dockerImageRepository": "registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7"
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${JENKINS_SLAVE_NAME}",
+                "labels": {
+                    "role": "jenkins-slave"
+                },
+                "annotations": {
+                    "slave-label": "${JENKINS_SLAVE_NAME}"
+                }
+            }
+        },
+        {
+            "kind": "BuildConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${JENKINS_SLAVE_NAME}",
+                "labels": {
+                    "build": "${JENKINS_SLAVE_NAME}"
+                }
+            },
+            "spec": {
+                "runPolicy": "Serial",
+                "source": {
+                    "type": "Git",
+                    "git": {
+                        "uri": "${SOURCE_REPOSITORY_URL}",
+                        "ref": "${SOURCE_REPOSITORY_REF}"
+                    },
+                    "contextDir": "${CONTEXT_DIR}"
+                },
+                "strategy": {
+                    "type": "Docker",
+                    "dockerStrategy": {
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "jenkins-slave-base-rhel7:latest"
+                        }
+                    }
+                },
+                "output": {
+                    "to": {
+                        "kind": "ImageStreamTag",
+                        "name": "${JENKINS_SLAVE_NAME}:latest"
+                    }
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChange": {}
+                    }
+                ],
+                "resources": {},
+                "postCommit": {}
+            }
+        }
+    ]
+}

--- a/jenkins-slaves/templates/jenkins-slave-ansible-stacks-template.json
+++ b/jenkins-slaves/templates/jenkins-slave-ansible-stacks-template.json
@@ -114,6 +114,10 @@
                             {
                                 "name": "ANSIBLE_STACKS_SOURCE_REPOSITORY_REF",
                                 "value": "${ANSIBLE_STACKS_SOURCE_REPOSITORY_REF}"
+                            },
+                            {
+                                "name": "ANSIBLE_YUM_REPO",
+                                "value": "${ANSIBLE_YUM_REPO}"
                             }
                         ]
                     }

--- a/jenkins-slaves/templates/jenkins-slave-ansible-stacks-template.json
+++ b/jenkins-slaves/templates/jenkins-slave-ansible-stacks-template.json
@@ -20,7 +20,7 @@
             "required": true
         },
         {
-            "description": "Git source URI for application",
+            "description": "Git source URI for application ",
             "name": "SOURCE_REPOSITORY_URL",
             "value": "https://github.com/redhat-cop/containers-quickstarts.git",
             "required": true
@@ -36,6 +36,24 @@
             "name": "CONTEXT_DIR",
             "value": "jenkins-slaves/jenkins-slave-ansible-stacks",
             "required": false
+        },
+        {
+            "description": "Git source URI for application",
+            "name": "ANSIBLE_STACKS_SOURCE_REPOSITORY_URL",
+            "value": "https://github.com/rht-labs/ansible-stacks.git",
+            "required": true
+        },
+        {
+            "description": "Git branch/tag reference",
+            "name": "ANSIBLE_STACKS_SOURCE_REPOSITORY_REF",
+            "value": "master",
+            "required": true
+        },
+        {
+            "description": "Git branch/tag reference",
+            "name": "ANSIBLE_YUM_REPO",
+            "value": "rhel-7-server-ose-3.3-rpms",
+            "required": true
         }
     ],
     "objects": [
@@ -87,7 +105,17 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "name": "jenkins-slave-base-rhel7:latest"
-                        }
+                        },
+                        "env": [
+                            {
+                                "name": "ANSIBLE_STACKS_SOURCE_REPOSITORY_URL",
+                                "value": "${ANSIBLE_STACKS_SOURCE_REPOSITORY_URL}"
+                            },
+                            {
+                                "name": "ANSIBLE_STACKS_SOURCE_REPOSITORY_REF",
+                                "value": "${ANSIBLE_STACKS_SOURCE_REPOSITORY_REF}"
+                            }
+                        ]
                     }
                 },
                 "output": {


### PR DESCRIPTION
#### What is this PR About?
This pull request adds a jenkins slave image for using ansible-stacks from a jenkins slave. This came out of work with a recent engagement where we provisioned projects and resources in OpenShift.

#### How do we test this?
See the README.md for instantiating the template to build the image. Then run the image in Jenkins with sample code to test. The jenkins service account will need self-provisioner role for the given example to succeed.