### PR TITLE
Fix issue with RHEL 7.4 and yum-config-manager

### DIFF
--- a/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
@@ -11,10 +11,9 @@ LABEL com.redhat.component="jenkins-slave-image-mgmt" \
 USER root
 
 RUN yum repolist > /dev/null && \
-    yum-config-manager --enable rhel-7-server-extras-rpms && \
     yum clean all && \
     INSTALL_PKGS="skopeo" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    yum install -y --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all
 


### PR DESCRIPTION
#### What is this PR About?
Provides a workaround to an [issue](https://bugzilla.redhat.com/show_bug.cgi?id=1479388) when using `yum-config-manager` in a RHEL 7.4 base image

#### How do we test this?
Follow the instructions in the README. Change the following template parameters:

* SOURCE_REPOSITORY_URL=https://github.com/sabre1041/containers-quickstarts.git
* SOURCE_REPOSITORY_REF=yum-install-fix

#### Is there an existing issue?

#42 

cc: @redhat-cop/containerize-it
