### PR TITLE
Feature/jenkins slave npm

### DIFF
--- a/jenkins-slaves/jenkins-slave-npm/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-npm/Dockerfile
@@ -1,6 +1,5 @@
 #invoke npm in jenkinsfile: sh "scl enable rh-nodejs6 'npm run build'"
-FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7
-USER root
+FROM openshift3/jenkins-slave-base-rhel7
 
 ENV NODEJS_VERSION=8 \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
@@ -10,12 +9,9 @@ ENV NODEJS_VERSION=8 \
     PROMPT_COMMAND=". /usr/local/bin/scl_enable"
 COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 
-RUN yum remove -y rh-nodejs4; \
-    yum repolist > /dev/null && \
-    INSTALL_PKGS="rh-nodejs8 rh-nodejs8-npm rh-nodejs8-nodejs-nodemon nss_wrapper redhat-lsb libXScrnSaver xdg-utils wget" && \
+RUN INSTALL_PKGS="rh-nodejs8 rh-nodejs8-npm rh-nodejs8-nodejs-nodemon nss_wrapper redhat-lsb libXScrnSaver xdg-utils wget" && \
     yum install -y --setopt=tsflags=nodocs \
       --enablerepo=rhel-server-rhscl-7-rpms \
-      --enablerepo=rhel-7-server-optional-rpms \
       --enablerepo=rhel-7-server-optional-rpms \
       --disablerepo=rhel-7-server-htb-rpms \
       $INSTALL_PKGS && \
@@ -29,5 +25,3 @@ ENV CHROME_BIN /bin/google-chrome
 
 USER 1001
 
-RUN git config --global user.email "jenkins@redhat-cop.com" && \
-    git config --global user.name "jenkins"

--- a/jenkins-slaves/jenkins-slave-npm/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-npm/Dockerfile
@@ -1,0 +1,33 @@
+#invoke npm in jenkinsfile: sh "scl enable rh-nodejs6 'npm run build'"
+FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7
+USER root
+
+ENV NODEJS_VERSION=8 \
+    NPM_CONFIG_PREFIX=$HOME/.npm-global \
+    PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
+    BASH_ENV=/usr/local/bin/scl_enable \
+    ENV=/usr/local/bin/scl_enable \
+    PROMPT_COMMAND=". /usr/local/bin/scl_enable"
+COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
+
+RUN yum remove -y rh-nodejs4; \
+    yum repolist > /dev/null && \
+    INSTALL_PKGS="rh-nodejs8 rh-nodejs8-npm rh-nodejs8-nodejs-nodemon nss_wrapper redhat-lsb libXScrnSaver xdg-utils wget" && \
+    yum install -y --setopt=tsflags=nodocs \
+      --enablerepo=rhel-server-rhscl-7-rpms \
+      --enablerepo=rhel-7-server-optional-rpms \
+      --enablerepo=rhel-7-server-optional-rpms \
+      --disablerepo=rhel-7-server-htb-rpms \
+      $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y && \
+    rm -rf /var/cache/yum
+
+ADD https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm google-chrome-stable_current_x86_64.rpm
+RUN yum -y localinstall google-chrome-stable_current_x86_64.rpm --disablerepo=rhel-7-server-htb-rpms
+ENV CHROME_BIN /bin/google-chrome
+
+USER 1001
+
+RUN git config --global user.email "jenkins@redhat-cop.com" && \
+    git config --global user.name "jenkins"

--- a/jenkins-slaves/jenkins-slave-npm/README.md
+++ b/jenkins-slaves/jenkins-slave-npm/README.md
@@ -1,0 +1,24 @@
+# jenkins-slave-npm
+Provides a docker image of the nodejs v6 runtime with npm for use as a Jenkins slave.
+
+## Build
+`docker build -t jenkins-slave-npm .`
+
+## Build in OpenShift
+```bash
+oc process -f ../templates/jenkins-slave-generic-template.yml \
+    -p NAME=jenkins-slave-npm \
+    -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-npm \
+    | oc create -f -
+```
+For all params see the list in the `../templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../templates/jenkins-slave-generic-template.yml`.
+
+## Run
+For local running and experimentation run `docker run -i -t --rm jenkins-slave-npm /bin/bash` and have a play once inside the container.
+
+## Jenkins Running
+Add a new Kubernetes Container template called `jenkins-slave-npm` and specify this as the node when running builds. 
+```
+scl enable rh-nodejs6 'npm install'
+scl enable rh-nodejs6 'npm run build'
+```

--- a/jenkins-slaves/jenkins-slave-npm/README.md
+++ b/jenkins-slaves/jenkins-slave-npm/README.md
@@ -19,6 +19,6 @@ For local running and experimentation run `docker run -i -t --rm jenkins-slave-n
 ## Jenkins Running
 Add a new Kubernetes Container template called `jenkins-slave-npm` and specify this as the node when running builds. 
 ```
-scl enable rh-nodejs6 'npm install'
-scl enable rh-nodejs6 'npm run build'
+npm install
+npm run build
 ```

--- a/jenkins-slaves/jenkins-slave-npm/README.md
+++ b/jenkins-slaves/jenkins-slave-npm/README.md
@@ -1,8 +1,11 @@
 # jenkins-slave-npm
 Provides a docker image of the nodejs v8 runtime with npm for use as a Jenkins slave.
 
-## Build
+## Build local
 `docker build -t jenkins-slave-npm .`
+
+## Run local
+For local running and experimentation run `docker run -i -t jenkins-slave-npm /bin/bash` and have a play once inside the container.
 
 ## Build in OpenShift
 ```bash
@@ -13,11 +16,10 @@ oc process -f ../templates/jenkins-slave-generic-template.yml \
 ```
 For all params see the list in the `../templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../templates/jenkins-slave-generic-template.yml`.
 
-## Run
-For local running and experimentation run `docker run -i -t --rm jenkins-slave-npm /bin/bash` and have a play once inside the container.
+## Jenkins
+Add a new Kubernetes Container template called `jenkins-slave-npm` (if you've build and pushed the container image locally) and specify this as the node when running builds. If you're using the template attached; the `role: jenkins-slave` is attached and Jenkins should automatically discover the slave for you. Further instructions can be found [here](https://docs.openshift.com/container-platform/3.7/using_images/other_images/jenkins.html#using-the-jenkins-kubernetes-plug-in-to-run-jobs).
 
-## Jenkins Running
-Add a new Kubernetes Container template called `jenkins-slave-npm` and specify this as the node when running builds. 
+Add this new Kubernetes Container template and specify this as the node when running builds. 
 ```
 npm install
 npm run build

--- a/jenkins-slaves/jenkins-slave-npm/contrib/bin/scl_enable
+++ b/jenkins-slaves/jenkins-slave-npm/contrib/bin/scl_enable
@@ -1,0 +1,3 @@
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable rh-nodejs8


### PR DESCRIPTION
#### What is this PR About?
Describe the contents of the PR
adding an npm slave with some extra juice that we use on residencies. Contains latest LTS version of node (v8x), google chrome for headless browser testing as part of CI and some basic git config for Jenkins when pushing repo tags.

#### How do we test this?
Provide commands/steps to test this PR.
As with the other PRs, build and run the image locally. $CHROME_BIN, npm and node all avail via env vars and path.

cc: @redhat-cop/containerize-it
