### PR TITLE
Add separate Dockerfile for RHEL, fixes #87

### DIFF
--- a/jenkins-slaves/jenkins-slave-golang/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-golang/Dockerfile.rhel7
@@ -1,4 +1,13 @@
-FROM openshift/jenkins-slave-base-centos7:latest
+FROM openshift3/jenkins-slave-base-rhel7
+
+LABEL com.redhat.component="jenkins-slave-golang-rhel7-docker" \
+      name="openshift3/jenkins-slave-golang-rhel7" \
+      version="3.9" \
+      architecture="x86_64" \
+      release="1" \
+      io.k8s.display-name="Jenkins Slave Golang" \
+      io.k8s.description="The jenkins slave golang image has the go runtime on top of the jenkins slave base image." \
+      io.openshift.tags="openshift,jenkins,slave,golang"
 
 ENV GO_VERSION=1.10.2 \
     GOROOT=/usr/local/go \

--- a/jenkins-slaves/templates/jenkins-slave-generic-template.yml
+++ b/jenkins-slaves/templates/jenkins-slave-generic-template.yml
@@ -39,6 +39,7 @@ objects:
       type: Git
     strategy:
       dockerStrategy:
+        dockerfilePath: "${DOCKERFILE_PATH}"
         from:
           kind: DockerImage
           name: "${BUILDER_IMAGE_NAME}"
@@ -74,5 +75,9 @@ parameters:
   displayName: Image tag for Jenkins slave.
   description: This is the image tag used for the Jenkins slave.
   value: latest
+- name: DOCKERFILE_PATH
+  displayName: Path to Dockerfile
+  description: Path for alternate Dockerfile to use for build
+  value: Dockerfile.rhel7
 labels:
   template: build-pod-template


### PR DESCRIPTION
#### What is this PR About?
Add separate Dockerfile for RHEL 7

#### How do we test this?
`oc process -f jenkins-slaves/templates/jenkins-slave-generic-template.yml -p NAME=jenkins-slave-golang -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-golang | oc create -f -`

cc: @redhat-cop/containerize-it
