### PR TITLE
Adding ansible_connection setting for localhost for gitlab-ce

### DIFF
--- a/gitlab-ce/inventory/hosts
+++ b/gitlab-ce/inventory/hosts
@@ -1,2 +1,2 @@
 [seed-hosts]
-localhost
+localhost ansible_connection=local


### PR DESCRIPTION
#### What is this PR About?
Fixing the gitlab-ce inventory to have the `ansible_connection=local` setting so it can be run on newer versions of Ansible.

Had someone run the steps in the README for gitlab-ce and they were getting the 'failed to connect to localhost' issue. This resolves it.

#### How do we test this?
Run the steps from the gitlab-ce README.

cc: @redhat-cop/containerize-it
