### PR TITLE
Updating tool-box README to reflect moving repos

### DIFF
--- a/tool-box/README.md
+++ b/tool-box/README.md
@@ -20,7 +20,7 @@ Assuming you have the [CLI installed](https://docs.openshift.com/container-platf
 
 Build the container and deploy it in OpenShift:
 
-`$ oc new-app https://github.com/rht-labs/labs-ci-cd --name=tool-box --context-dir=docker/tool-box`
+`$ oc new-app https://github.com/redhat-cop/containers-quickstarts --name=tool-box --context-dir=tool-box`
 
 Wait for the build to finish and the container to deploy. You can now log into the terminal via the pod web console.
 
@@ -36,11 +36,11 @@ Copy the NAME of the `tool-box` pod and then remote shell into it:
 
 Clone this repo:
 
-`$ git clone https://github.com/rht-labs/labs-ci-cd`
+`$ git clone https://github.com/redhat-cop/containers-quickstarts`
 
 Build the container:
 
-`[labs-ci-cd/docker/tool-box]$ docker build -t tool-box .`
+`[containers-quickstarts/tool-box]$ docker build -t tool-box .`
 
 Run the container in the background, then shell into. There are important things the container does at boot that you don't want to override. If you need sudo for docker:
 


### PR DESCRIPTION
#### What is this PR About?
Since this was moved from rht-labs/labs-ci-cd to redhat-cop/containers-quickstarts, the README was out of date.

#### How do we test this?
Run the commands provided in the README.

cc: @redhat-cop/containerize-it
