### PR TITLE
Updating gitlab template to have namespace parameter

### DIFF
--- a/gitlab-ce/files/templates/gitlab-ssl.yml
+++ b/gitlab-ce/files/templates/gitlab-ssl.yml
@@ -21,7 +21,7 @@ objects:
         but allows users to run with any UID and any GID.
     name: anyuid
   users:
-  - system:serviceaccount:gitlab:${APPLICATION_NAME}-user
+  - system:serviceaccount:${NAMESPACE}:${APPLICATION_NAME}-user
 - kind: ImageStream
   apiVersion: v1
   metadata:
@@ -536,3 +536,7 @@ parameters:
   displayName: redis volume size
   name: REDIS_VOL_SIZE
   value: 512Mi
+- name: NAMESPACE
+  description: Namespace where Jenkins will be deployed.
+  displayName: Namespace
+  value: gitlab

--- a/gitlab-ce/files/templates/gitlab-ssl.yml
+++ b/gitlab-ce/files/templates/gitlab-ssl.yml
@@ -537,6 +537,6 @@ parameters:
   name: REDIS_VOL_SIZE
   value: 512Mi
 - name: NAMESPACE
-  description: Namespace where Jenkins will be deployed.
+  description: Namespace where Gitlab will be deployed.
   displayName: Namespace
   value: gitlab


### PR DESCRIPTION
#### What is this PR About?
Currently the template assumes gitlab will be deployed in the gitlab namespace.

#### How do we test this?
Run the steps in the README.

cc: @redhat-cop/containerize-it
