### PR TITLE
Add redirection for insecure HTTP access

### DIFF
--- a/gitlab-ce/files/templates/gitlab-ssl.yml
+++ b/gitlab-ce/files/templates/gitlab-ssl.yml
@@ -440,6 +440,7 @@ objects:
       targetPort: 443-https
     tls:
       termination: passthrough
+      insecureEdgeTerminationPolicy: Redirect
     wildcardPolicy: None
 parameters:
 - description: A label that will be seen by the user at login


### PR DESCRIPTION
#### What is this PR About?
Add HTTP->HTTPS redirection to GitLab template

#### How do we test this?
Deploy the template and then attempt to access GitLab over HTTP. You should be redirected to the same URL with HTTPS instead.

cc: @redhat-cop/containerize-it
