### PR TITLE
Runonce toolbox

### DIFF
--- a/tool-box/Dockerfile
+++ b/tool-box/Dockerfile
@@ -11,11 +11,12 @@ RUN dnf -y update && \
     mkdir -m 775 $HOME && \
     chmod 775 /etc/passwd && \
     pip install git+https://github.com/ansible/ansible.git@stable-2.5
-    
+
 WORKDIR $HOME
 
-ADD ./s2i /usr/libexec/s2i
+ADD ./root /
 
 USER 1001
 
-CMD ["/usr/libexec/s2i/run"]
+ENTRYPOINT ["/usr/local/bin/run"]
+CMD ["sleep", "infinity"]

--- a/tool-box/README.md
+++ b/tool-box/README.md
@@ -1,6 +1,6 @@
 # Tool Box
 
-This container exists to help folks that can't install ansible, git or other necessary tools. It is not to be used in any time of production setting and is not suppportable under an OpenShift subscription. 
+This container exists to help folks that can't install ansible, git or other necessary tools. It is not to be used in any time of production setting and is not suppportable under an OpenShift subscription.
 
 ## What's in the box?
 
@@ -20,19 +20,23 @@ Assuming you have the [CLI installed](https://docs.openshift.com/container-platf
 
 Build the container and deploy it in OpenShift:
 
-`$ oc new-app https://github.com/redhat-cop/containers-quickstarts --name=tool-box --context-dir=tool-box`
-
-Wait for the build to finish and the container to deploy. You can now log into the terminal via the pod web console.
-
-If you want to shell in from your terminal, query the running pods:
-
-`$ oc get pods -l app=tool-box`
-
-Copy the NAME of the `tool-box` pod and then remote shell into it:
-
-`$ oc rsh <NAME>`
+`$ oc run -i -t tool-box-test --image=quay.io/redhat-cop/tool-box --rm bash`
 
 ### Docker
+
+Run the container in the background, then shell into. There are important things the container does at boot that you don't want to override. If you need sudo for docker:
+
+`$ sudo docker run -it tool-box /bin/bash`
+
+If you don't need sudo:
+
+`$ docker run -it tool-box /bin/bash`
+
+## Building the Image
+
+This image is available publicly at `quay.io/redhat-cop/tool-box`, so there's no need to build it yourself. If you need to build it for development reasons, here's how.
+
+### With Docker
 
 Clone this repo:
 
@@ -42,10 +46,6 @@ Build the container:
 
 `[containers-quickstarts/tool-box]$ docker build -t tool-box .`
 
-Run the container in the background, then shell into. There are important things the container does at boot that you don't want to override. If you need sudo for docker:
+### In OpenShift
 
-`$ sudo docker exec -it $(sudo docker run -d tool-box) /bin/bash`
-
-If you don't need sudo:
-
-`$ docker exec -it $(docker run -d tool-box) /bin/bash`
+`oc new-build https://github.com/redhat-cop/containers-quickstarts --name=tool-box --context-dir=tool-box`

--- a/tool-box/README.md
+++ b/tool-box/README.md
@@ -1,3 +1,5 @@
+[![Docker Repository on Quay](https://quay.io/repository/redhat-cop/tool-box/status "Docker Repository on Quay")](https://quay.io/repository/redhat-cop/tool-box)
+
 # Tool Box
 
 This container exists to help folks that can't install ansible, git or other necessary tools. It is not to be used in any time of production setting and is not suppportable under an OpenShift subscription.

--- a/tool-box/root/usr/local/bin/run
+++ b/tool-box/root/usr/local/bin/run
@@ -16,4 +16,4 @@ else
   echo "User $USER_ID already exists"
 fi
 
-sleep infinity
+exec "$@"


### PR DESCRIPTION
#### What is this PR About?
Updating the tool-box image so that it does not need to be run as a daemon

#### How do we test this?

Follow the updated README instructions to exercise the image. Since it is not yet pushed to quay, you will need to build it. To test the OpenShift build, use the following:

```
oc new-build https://github.com/etsauer/containers-quickstarts#runonce-toolbox --name=tool-box --context-dir=tool-box
```

cc: @redhat-cop/containerize-it
