### PR TITLE
Locking 'jenkins-slave-ansible' on 2.5.x of Ansible

### DIFF
--- a/jenkins-slaves/jenkins-slave-ansible/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-ansible/Dockerfile
@@ -2,11 +2,10 @@ FROM openshift3/jenkins-slave-base-rhel7:latest
 
 USER root
 
-RUN INSTALL_PKGS="ansible" && \
-    yum install -y --setopt=tsflags=nodocs \
+RUN yum install -y --setopt=tsflags=nodocs \
       --disablerepo=* --enablerepo=rhel-7-server-rpms --enablerepo=rhel-7-server-extras-rpms \
-      $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
+      https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.5.8-1.el7.ans.noarch.rpm && \
+    rpm -V ansible && \
     yum clean all -y && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
#### What is this PR About?
Updating the Dockerfile for `jenkins-slave-ansible` to lock it on a `2.5.x` version of Ansible

#### How do we test this?
1. Create a new OCP project:
 ` > oc new-project my-test`
2. Use the template to instantiate the build of the image:
 `> oc process -f jenkins-slaves/templates/jenkins-slave-generic-template.yml -p 'SOURCE_REPOSITORY_URL=https://github.com/oybed/containers-quickstarts.git' -p 'SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-ansible' -p 'BUILDER_IMAGE_NAME=registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:latest' -p 'NAME=jenkins-slave-ansible' -p 'SOURCE_REPOSITORY_REF=jenkins-slave-ansible' -p 'DOCKERFILE_PATH=Dockerfile' | oc apply -f -`
3. Validate that the build succeeded and that an new image was created
`> oc get builds`
4. Validate that the ansible version in the image is correct:
```> oc run jenkins-slave-ansible --image=`oc get is jenkins-slave-ansible -o=custom-columns=NAME:.status.dockerImageRepository --no-headers` --command -- ansible --version```
`> oc get pods`
`> oc logs <pod-name>`
... validate that ansible version is showing `2.5.8`

resolves #123 

cc: @redhat-cop/containerize-it
