### PR TITLE
Add pip to Jenkins Ansible Slave, fixes #128

### DIFF
--- a/jenkins-slaves/jenkins-slave-ansible/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-ansible/Dockerfile
@@ -1,10 +1,12 @@
-FROM openshift3/jenkins-slave-base-rhel7:latest
+FROM openshift/jenkins-slave-base-centos7:latest
 
-USER root
+ENV ANSIBLE_VERSION=2.5.8 \
+    ANSIBLE_REVISION=1
 
-RUN yum install -y --setopt=tsflags=nodocs \
-      --disablerepo=* --enablerepo=rhel-7-server-rpms --enablerepo=rhel-7-server-extras-rpms \
-      https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.5.8-1.el7.ans.noarch.rpm && \
+RUN INSTALL_PKGS="python2-pip" && \
+    yum install -y epel-release && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
+      https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-${ANSIBLE_VERSION}-${ANSIBLE_REVISION}.el7.ans.noarch.rpm && \
     rpm -V ansible && \
     yum clean all -y && \
     rm -rf /var/cache/yum

--- a/jenkins-slaves/jenkins-slave-ansible/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-ansible/Dockerfile.rhel7
@@ -12,8 +12,11 @@ LABEL com.redhat.component="jenkins-slave-ansible-rhel7-docker" \
 ENV ANSIBLE_VERSION=2.5.8 \
     ANSIBLE_REVISION=1
 
-RUN yum install -y --setopt=tsflags=nodocs \
+RUN INSTALL_PKGS="python2-pip" && \
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum install -y --setopt=tsflags=nodocs \
       --disablerepo=* --enablerepo=rhel-7-server-rpms --enablerepo=rhel-7-server-extras-rpms \
+      --enablerepo=epel $INSTALL_PKGS \
       https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-${ANSIBLE_VERSION}-${ANSIBLE_REVISION}.el7.ans.noarch.rpm && \
     rpm -V ansible && \
     yum clean all -y && \


### PR DESCRIPTION
#### What is this PR About?
Add pip to Jenkins Ansible Slave

#### How do we test this?
Follow steps in README, then command below
```
oc run ansible-slave -i -t --image=docker-registry.default.svc:5000/ansible-slave/jenkins-slave-ansible --command -- pip -V      
If you don't see a command prompt, try pressing enter.
pip 8.1.2 from /usr/lib/python2.7/site-packages (python 2.7)
```

cc: @redhat-cop/containerize-it
