### PR TITLE
add dep into golang build slave

### DIFF
--- a/jenkins-slaves/jenkins-slave-golang/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-golang/Dockerfile
@@ -9,8 +9,10 @@ ADD https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz /usr/
 RUN mkdir -p /usr/src/go/src/redhat && \
     tar -xzf /usr/go${GO_VERSION}.linux-amd64.tar.gz && \
     mv $(pwd)/go /usr/local/ && \
+    go get -u github.com/golang/dep/cmd/dep && \
     chown -R 1001 /usr/src/go && \
     chown -R 1001 /usr/local/go && \
+    chown -R 1001 ${HOME}/.cache/go-build && \
     rm -f /usr/go${GO_VERSION}.linux-amd64.tar.gz
 
 USER 1001


### PR DESCRIPTION
#### What is this PR About?
Adding `dep` into the golang build slave. There are numerous dependency managers for golang. Dep is the official experiment dependency manager. Opening this PR to decide if we want to include a dependency manager or require image builds downstream to incorporate the appropriate dependency manager.

#### How do we test this?
docker build .

cc: @redhat-cop/containerize-it
