### PR TITLE
Added repository for missing dependency in new chrome

### DIFF
--- a/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
@@ -31,6 +31,7 @@ RUN INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-n
     yum -y localinstall \
       --disablerepo=* \
       --enablerepo=rhel-7-server-rpms \
+      --enablerepo=rhel-7-server-optional-rpms \
       google-chrome-stable_current_x86_64.rpm && \
     rm google-chrome-stable_current_x86_64.rpm && \
     rpm -V $INSTALL_PKGS google-chrome-stable && \


### PR DESCRIPTION
#### What is this PR About?
yum fails:

Error: Package: google-chrome-stable-70.0.3538.77-1.x86_64 (/google-chrome-stable_current_x86_64) Requires: liberation-fonts

#### How do we test this?
(On RHEL)
docker build .

cc: @redhat-cop/containerize-it
