### PR TITLE
Tie Jenkins slave images to match OCP release

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ A set of images we've developed for running as slave pods in a Jenkins Pipeline 
 * [Image Promotion](./jenkins-slaves/jenkins-slave-image-mgmt)
 * [Extended Maven Slave](./jenkins-slaves/jenkins-slave-mvn)
 * [Ruby](./jenkins-slaves/jenkins-slave-ruby)
+* [Arachni](./jenkins-slaves/jenkins-slave-arachni)
+* [Gradle](./jenkins-slaves/jenkins-slave-gradle)
+* [MongoDB](./jenkins-slaves/jenkins-slave-mongodb)
+* [Node](./jenkins-slaves/jenkins-slave-npm)
+* [Python](./jenkins-slaves/jenkins-slave-python)
+* [ZAP](./jenkins-slaves/jenkins-slave-zap)
 
 ### Developer Tools
 

--- a/jenkins-slaves/jenkins-slave-ansible/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-ansible/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-base-centos7
+FROM openshift/jenkins-slave-base-centos7:v3.11
 
 ENV BASH_ENV=/usr/local/bin/scl_enable \
     ENV=/usr/local/bin/scl_enable \

--- a/jenkins-slaves/jenkins-slave-ansible/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-ansible/Dockerfile.rhel7
@@ -1,8 +1,8 @@
-FROM openshift3/jenkins-slave-base-rhel7:latest
+FROM openshift3/jenkins-slave-base-rhel7:v3.11
 
 LABEL com.redhat.component="jenkins-slave-ansible-rhel7-docker" \
       name="openshift3/jenkins-slave-ansible-rhel7" \
-      version="3.9" \
+      version="3.11" \
       architecture="x86_64" \
       release="1" \
       io.k8s.display-name="Jenkins Slave Ansible" \

--- a/jenkins-slaves/jenkins-slave-ansible/README.md
+++ b/jenkins-slaves/jenkins-slave-ansible/README.md
@@ -1,6 +1,6 @@
 # Jenkins Ansible Slave
 
-This is a Jenkins Slave designed to run in OpenShift as described [here](https://docs.openshift.com/container-platform/3.10/using_images/other_images/jenkins.html#using-the-jenkins-kubernetes-plug-in). The slave should stay in sync with [the openshift applier image](https://github.com/redhat-cop/openshift-applier/tree/master/images/openshift-applier) in order to provide a common runtime environment.
+This is a Jenkins Slave designed to run in OpenShift as described [here](https://docs.openshift.com/container-platform/3.11/using_images/other_images/jenkins.html#using-the-jenkins-kubernetes-plug-in). The slave should stay in sync with [the openshift applier image](https://github.com/redhat-cop/openshift-applier/tree/master/images/openshift-applier) in order to provide a common runtime environment.
 
 Provides a docker image with ansible for use as a Jenkins slave.
 

--- a/jenkins-slaves/jenkins-slave-arachni/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-arachni/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-base-centos7:latest
+FROM openshift/jenkins-slave-base-centos7:v3.11
 
 ARG VERSION=1.5.1
 ARG WEB_VERSION=0.5.12

--- a/jenkins-slaves/jenkins-slave-arachni/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-arachni/Dockerfile.rhel7
@@ -1,8 +1,8 @@
-FROM openshift3/jenkins-slave-base-rhel7
+FROM openshift3/jenkins-slave-base-rhel7:v3.11
 
 LABEL com.redhat.component="jenkins-slave-arachni-rhel7-docker" \
       name="openshift3/jenkins-slave-arachni-rhel7" \
-      version="3.9" \
+      version="3.11" \
       architecture="x86_64" \
       release="1" \
       io.k8s.display-name="Jenkins Slave Arachni" \

--- a/jenkins-slaves/jenkins-slave-golang/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-base-centos7
+FROM openshift/jenkins-slave-base-centos7:v3.11
 
 ENV GO_VERSION=1.10.2 \
     GOROOT=/usr/local/go \

--- a/jenkins-slaves/jenkins-slave-golang/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-golang/Dockerfile.rhel7
@@ -1,8 +1,8 @@
-FROM openshift3/jenkins-slave-base-rhel7
+FROM openshift3/jenkins-slave-base-rhel7:v3.11
 
 LABEL com.redhat.component="jenkins-slave-golang-rhel7-docker" \
       name="openshift3/jenkins-slave-golang-rhel7" \
-      version="3.9" \
+      version="3.11" \
       architecture="x86_64" \
       release="1" \
       io.k8s.display-name="Jenkins Slave Golang" \

--- a/jenkins-slaves/jenkins-slave-gradle/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-gradle/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-base-centos7
+FROM openshift/jenkins-slave-base-centos7:v3.11
 
 ENV GRADLE_VERSION=4.8
 

--- a/jenkins-slaves/jenkins-slave-gradle/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-gradle/Dockerfile.rhel7
@@ -1,8 +1,8 @@
-FROM openshift3/jenkins-slave-base-rhel7
+FROM openshift3/jenkins-slave-base-rhel7:v3.11
 
 LABEL com.redhat.component="jenkins-slave-gradle-rhel7-docker" \
       name="openshift3/jenkins-slave-gradle-rhel7" \
-      version="3.9" \
+      version="3.11" \
       architecture="x86_64" \
       release="1" \
       io.k8s.display-name="Jenkins Slave Gradle" \

--- a/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
+FROM openshift3/jenkins-slave-base-rhel7:v3.11
 
 MAINTAINER Andrew Block <ablock@redhat.com>
 

--- a/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
@@ -14,7 +14,7 @@ RUN INSTALL_PKGS="skopeo" && \
     yum install -y --setopt=tsflags=nodocs \
       --enablerepo=rhel-7-server-rpms \
       --enablerepo=rhel-7-server-extras-rpms \
-      INSTALL_PKGS && \
+      $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all
 

--- a/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
@@ -12,7 +12,6 @@ USER root
 
 RUN INSTALL_PKGS="skopeo" && \
     yum install -y --setopt=tsflags=nodocs \
-      --disablerepo=* \
       --enablerepo=rhel-7-server-rpms \
       --enablerepo=rhel-7-server-extras-rpms \
       INSTALL_PKGS && \

--- a/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift3/jenkins-slave-base-rhel7:v3.11
+FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 
 MAINTAINER Andrew Block <ablock@redhat.com>
 

--- a/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7
+FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 
 MAINTAINER Andrew Block <ablock@redhat.com>
 

--- a/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
@@ -10,10 +10,12 @@ LABEL com.redhat.component="jenkins-slave-image-mgmt" \
       io.openshift.tags="openshift,jenkins,slave,copy"
 USER root
 
-RUN yum repolist > /dev/null && \
-    yum clean all && \
-    INSTALL_PKGS="skopeo" && \
-    yum install -y --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs $INSTALL_PKGS && \
+RUN INSTALL_PKGS="skopeo" && \
+    yum install -y --setopt=tsflags=nodocs \
+      --disablerepo=* \
+      --enablerepo=rhel-7-server-rpms \
+      --enablerepo=rhel-7-server-extras-rpms \
+      INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all
 

--- a/jenkins-slaves/jenkins-slave-image-mgmt/README.md
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/README.md
@@ -15,7 +15,7 @@ A [template](../templates/jenkins-slave-image-mgmt-template.json) is available p
 Execute the following command to instantiate the template:
 
 ```
-oc process -f ../templates/jenkins-slave-image-mgmt-template.json | oc apply -f-
+oc process -f ../templates/jenkins-slave-image-mgmt-template.yml | oc apply -f-
 ```
 
 A new image build will be started automatically

--- a/jenkins-slaves/jenkins-slave-mongodb/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-mongodb/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-base-centos7:latest
+FROM openshift/jenkins-slave-base-centos7:v3.11
 
 USER root
 

--- a/jenkins-slaves/jenkins-slave-mongodb/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-mongodb/Dockerfile.rhel7
@@ -1,8 +1,8 @@
-FROM openshift3/jenkins-slave-base-rhel7
+FROM openshift3/jenkins-slave-base-rhel7:v3.11
 
 LABEL com.redhat.component="jenkins-slave-mongodb-rhel7-docker" \
       name="openshift3/jenkins-slave-mongodb-rhel7" \
-      version="3.9" \
+      version="3.11" \
       architecture="x86_64" \
       release="1" \
       io.k8s.display-name="Jenkins Slave MongoDB" \

--- a/jenkins-slaves/jenkins-slave-mvn/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-mvn/Dockerfile
@@ -1,2 +1,2 @@
-FROM openshift/jenkins-slave-maven-rhel7:latest
+FROM openshift/jenkins-slave-maven-rhel7:v3.11
 ADD settings.xml $HOME/.m2/settings.xml

--- a/jenkins-slaves/jenkins-slave-mvn/README.md
+++ b/jenkins-slaves/jenkins-slave-mvn/README.md
@@ -1,3 +1,13 @@
 # Jenkins Maven Slave
 
 This slave extends [the Jenkins Maven Slave shipped with OpenShift](https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/openshift3/jenkins-slave-maven-rhel7) to provide a settings.xml that proxies all dependencies through a nexus server deployed to the same namespace. This type of setup makes sense in a Lab setting, such as [Open Innovation Labs CI/CD](https://github.com/rht-labs/labs-ci-cd) environment. For most customer engagements, you'll to update this proxy/password to use an central, enterprise artifact repo which is unlikely to be deployed in the same namespace. Or simply use the OpenShift supplied base image directly and provide artifact repository info in the application build.
+
+## Build in OpenShift
+```bash
+oc process -f ../templates/jenkins-slave-generic-template.yml \
+    -p NAME=jenkins-slave-mvn \
+    -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-mvn \
+    -p DOCKERFILE_PATH=Dockerfile \
+    | oc create -f -
+```
+For all params see the list in the `../templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../templates/jenkins-slave-generic-template.yml`.

--- a/jenkins-slaves/jenkins-slave-npm/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-npm/Dockerfile
@@ -1,5 +1,5 @@
 #invoke npm in jenkinsfile: sh "scl enable rh-nodejs6 'npm run build'"
-FROM openshift/jenkins-slave-base-centos7
+FROM openshift/jenkins-slave-base-centos7:v3.11
 
 ENV NODEJS_VERSION=8 \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \

--- a/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
@@ -28,6 +28,7 @@ RUN INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-n
       --enablerepo=rhel-server-rhscl-7-rpms \
       --enablerepo=rhel-7-server-optional-rpms \
       --enablerepo=rhel-7-server-extras-rpms \
+      --enablerepo=google-chrome \
       $INSTALL_PKGS && \
     yum clean all -y && \
     rm -rf /var/cache/yum

--- a/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
@@ -1,9 +1,9 @@
 #invoke npm in jenkinsfile: sh "scl enable rh-nodejs6 'npm run build'"
-FROM openshift3/jenkins-slave-base-rhel7
+FROM openshift3/jenkins-slave-base-rhel7:v3.11
 
 LABEL com.redhat.component="jenkins-slave-nodejs-rhel7-docker" \
       name="openshift3/jenkins-slave-nodejs-rhel7" \
-      version="3.9" \
+      version="3.11" \
       architecture="x86_64" \
       release="1" \
       io.k8s.display-name="Jenkins Slave Nodejs" \
@@ -19,22 +19,16 @@ ENV NODEJS_VERSION=8 \
     CHROME_BIN=/bin/google-chrome
 
 COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
-ADD https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm google-chrome-stable_current_x86_64.rpm
+ADD src/google-chrome.repo /etc/yum.repos.d/
 
-RUN INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper redhat-lsb libXScrnSaver xdg-utils" && \
+RUN INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper redhat-lsb libXScrnSaver xdg-utils google-chrome-stable" && \
     yum install -y --setopt=tsflags=nodocs \
       --disablerepo=* \
       --enablerepo=rhel-7-server-rpms \
       --enablerepo=rhel-server-rhscl-7-rpms \
       --enablerepo=rhel-7-server-optional-rpms \
+      --enablerepo=rhel-7-server-extras-rpms \
       $INSTALL_PKGS && \
-    yum -y localinstall \
-      --disablerepo=* \
-      --enablerepo=rhel-7-server-rpms \
-      --enablerepo=rhel-7-server-optional-rpms \
-      google-chrome-stable_current_x86_64.rpm && \
-    rm google-chrome-stable_current_x86_64.rpm && \
-    rpm -V $INSTALL_PKGS google-chrome-stable && \
     yum clean all -y && \
     rm -rf /var/cache/yum
 

--- a/jenkins-slaves/jenkins-slave-npm/src/google-chrome.repo
+++ b/jenkins-slaves/jenkins-slave-npm/src/google-chrome.repo
@@ -1,0 +1,6 @@
+[google-chrome]
+name=google-chrome
+baseurl=https://dl.google.com/linux/chrome/rpm/stable/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub

--- a/jenkins-slaves/jenkins-slave-python/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-base-centos7
+FROM openshift/jenkins-slave-base-centos7:v3.11
 
 EXPOSE 8080
 

--- a/jenkins-slaves/jenkins-slave-python/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-python/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM openshift3/jenkins-slave-base-rhel7
+FROM openshift3/jenkins-slave-base-rhel7:v3.11
 
 EXPOSE 8080
 

--- a/jenkins-slaves/jenkins-slave-ruby/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-base-centos7
+FROM openshift/jenkins-slave-base-centos7:v3.11
 
 ENV RUBY_VERSION 2.4
 
@@ -13,7 +13,7 @@ It is simple, straight-forward, and extensible." \
   PATH=$PATH:/home/jenkins/bin \
   PROMPT_COMMAND=". /opt/app-root/etc/scl_enable" \
   HOME=/home/jenkins \
-  ORIGIN_CLIENT=https://github.com/openshift/origin/releases/download/v3.6.0/openshift-origin-client-tools-v3.6.0-c4dd4cf-linux-64bit.tar.gz
+  ORIGIN_CLIENT=https://mirror.openshift.com/pub/openshift-v3/clients/3.11.50/linux/oc.tar.gz
 
 
 LABEL summary="$SUMMARY" \
@@ -35,10 +35,8 @@ RUN yum install -y centos-release-scl && \
     yum remove -y origin-clients && \
     yum clean all -y
 
-RUN wget -O $HOME/origin-client.tar.gz $ORIGIN_CLIENT && \
-    tar -xzf $HOME/origin-client.tar.gz -C $HOME && \
-    cp $HOME/openshift-origin-client-tools-v3.6.0-c4dd4cf-linux-64bit/oc /usr/bin/oc && \
-    rm -rf origin-client*
+RUN curl $ORIGIN_CLIENT | tar -C /usr/local/bin/ -xzf - && \
+    chmod +x /usr/local/bin/oc
 
 # Copy extra files to the image.
 COPY ./root/ /

--- a/jenkins-slaves/templates/jenkins-slave-ansible-stacks-template.yml
+++ b/jenkins-slaves/templates/jenkins-slave-ansible-stacks-template.yml
@@ -34,7 +34,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: ${JENKINS_SLAVE_NAME}:latest
+        name: ${JENKINS_SLAVE_NAME}:v3.11
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -55,7 +55,7 @@ objects:
           value: ${ANSIBLE_YUM_REPO}
         from:
           kind: ImageStreamTag
-          name: jenkins-slave-base-rhel7:latest
+          name: jenkins-slave-base-rhel7:v3.11
       type: Docker
     triggers:
     - imageChange: {}

--- a/jenkins-slaves/templates/jenkins-slave-generic-template.yml
+++ b/jenkins-slaves/templates/jenkins-slave-generic-template.yml
@@ -74,7 +74,7 @@ parameters:
 - name: SLAVE_IMAGE_TAG
   displayName: Image tag for Jenkins slave.
   description: This is the image tag used for the Jenkins slave.
-  value: latest
+  value: v3.11
 - name: DOCKERFILE_PATH
   displayName: Path to Dockerfile
   description: Path for alternate Dockerfile to use for build

--- a/jenkins-slaves/templates/jenkins-slave-image-mgmt-template.yml
+++ b/jenkins-slaves/templates/jenkins-slave-image-mgmt-template.yml
@@ -33,7 +33,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: ${JENKINS_SLAVE_NAME}:latest
+        name: ${JENKINS_SLAVE_NAME}:v3.11
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -47,7 +47,7 @@ objects:
       dockerStrategy:
         from:
           kind: ImageStreamTag
-          name: jenkins-slave-base-rhel7:latest
+          name: jenkins-slave-base-rhel7:v3.11
       type: Docker
     triggers:
     - imageChange: {}

--- a/jenkins-slaves/templates/jenkins-slave-ruby-template.yml
+++ b/jenkins-slaves/templates/jenkins-slave-ruby-template.yml
@@ -22,7 +22,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: ${JENKINS_SLAVE_NAME}:latest
+        name: ${JENKINS_SLAVE_NAME}:v3.11
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -36,7 +36,7 @@ objects:
       dockerStrategy:
         from:
           kind: ImageStreamTag
-          name: jenkins-slave-base-centos7:latest
+          name: jenkins-slave-base-centos7:v3.11
       type: Docker
     triggers:
     - type: ConfigChange


### PR DESCRIPTION
#### What is this PR About?
This PR will cover the Jenkins slave images to match the OCP release and solve some existing issues on resultant slaves like npm and others, where we have seen unexpected results when running 'latest' tag of the base images when a new major version is available and the 'latest' tag is moved in the Red Hat Container Catalog.

#### How do we test this?
Build Jenkins slave images using instructions from the repository

cc: @redhat-cop/containerize-it
