### PR TITLE
Fix jenkins-slave-image-mgmt doc to reference .yml

### DIFF
--- a/jenkins-slaves/jenkins-slave-image-mgmt/README.md
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/README.md
@@ -10,12 +10,12 @@ Jenkins [Slave](https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds) 
 
 ## Instantiate Template
 
-A [template](../templates/jenkins-slave-image-mgmt-template.json) is available providing the necessary OpenShift components to build and make the slave image available to be referenced by Jenkins.
+A [template](../templates/jenkins-slave-image-mgmt-template.yml) is available providing the necessary OpenShift components to build and make the slave image available to be referenced by Jenkins.
 
 Execute the following command to instantiate the template:
 
 ```
-oc process -f ../templates/jenkins-slave-image-mgmt-template.json | oc apply -f-
+oc process -f ../templates/jenkins-slave-image-mgmt-template.yml | oc apply -f-
 ```
 
 A new image build will be started automatically


### PR DESCRIPTION
#### What is this PR About?
This fixes a reference from a .json file that doesn't exist to the appropriate .yml file.

resolves #146 

#### How do we test this?
Doc fix. Verify example points to existing .yml file

cc: @redhat-cop/containerize-it
