### PR TITLE
Set Jenkins root url in hygieia master

### DIFF
--- a/jenkins-masters/hygieia-plugin/.openshift/templates/jenkins-s2i.yml
+++ b/jenkins-masters/hygieia-plugin/.openshift/templates/jenkins-s2i.yml
@@ -33,6 +33,10 @@ objects:
         kind: ImageStreamTag
         name: jenkins2-s2i:latest
     source:
+      git:
+        uri: https://github.com/etsauer/containers-quickstarts.git
+        ref: jenkins-root-url
+      contextDir: jenkins-masters/hygieia-plugin/
       images:
       - as: null
         from:

--- a/jenkins-masters/hygieia-plugin/.openshift/templates/jenkins-s2i.yml
+++ b/jenkins-masters/hygieia-plugin/.openshift/templates/jenkins-s2i.yml
@@ -34,8 +34,8 @@ objects:
         name: jenkins2-s2i:latest
     source:
       git:
-        uri: https://github.com/etsauer/containers-quickstarts.git
-        ref: jenkins-root-url
+        uri: ${SOURCE_CODE_URL}
+        ref: ${SOURCE_CODE_REF}
       contextDir: jenkins-masters/hygieia-plugin/
       images:
       - as: null
@@ -53,3 +53,8 @@ objects:
           name: jenkins:latest
           namespace: openshift
       type: Source
+parameters:
+  name: SOURCE_CODE_URL
+  value: https://github.com/redhat-cop/containers-quickstarts.git
+  name: SOURCE_CODE_REF
+  value: master

--- a/jenkins-masters/hygieia-plugin/configuration/init.groovy.d/configure-jenkins.groovy
+++ b/jenkins-masters/hygieia-plugin/configuration/init.groovy.d/configure-jenkins.groovy
@@ -1,0 +1,75 @@
+#!/usr/bin/env groovy
+import jenkins.model.*
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView
+import groovy.json.JsonSlurper
+import hudson.tools.InstallSourceProperty
+
+import java.util.logging.Level
+import java.util.logging.Logger
+import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud
+import jenkins.model.JenkinsLocationConfiguration
+
+final def LOG = Logger.getLogger("LABS")
+
+LOG.log(Level.INFO,  'running configure-jenkins.groovy' )
+
+try {
+    // delete default OpenShift job
+    Jenkins.instance.items.findAll {
+        job -> job.name == 'OpenShift Sample'
+    }.each {
+        job -> job.delete()
+    }
+} catch (NullPointerException npe) {
+   LOG.log(Level.INFO, 'Failed to delete OpenShift Sample job')
+}
+// create a default build monitor view that includes all jobs
+// https://wiki.jenkins-ci.org/display/JENKINS/Build+Monitor+Plugin
+if ( Jenkins.instance.views.findAll{ view -> view instanceof com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView }.size == 0){
+  view = new BuildMonitorView('Build Monitor','Build Monitor')
+  view.setIncludeRegex('.*')
+  Jenkins.instance.addView(view)
+}
+
+
+
+// support custom CSS for htmlreports
+// https://stackoverflow.com/questions/35783964/jenkins-html-publisher-plugin-no-css-is-displayed-when-report-is-viewed-in-j
+System.setProperty("hudson.model.DirectoryBrowserSupport.CSP", "")
+
+// This is a helper to delete views in the Jenkins script console if needed
+// Jenkins.instance.views.findAll{ view -> view instanceof com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView }.each{ view -> Jenkins.instance.deleteView( view ) }
+
+println("WORKAROUND FOR BUILD_URL ISSUE, see: https://issues.jenkins-ci.org/browse/JENKINS-28466")
+
+def hostname = System.getenv('HOSTNAME')
+println "hostname> $hostname"
+
+def sout = new StringBuilder(), serr = new StringBuilder()
+def proc = "oc get pod ${hostname} -o jsonpath={.metadata.labels.name}".execute()
+proc.consumeProcessOutput(sout, serr)
+proc.waitForOrKill(3000)
+println "out> $sout err> $serr"
+
+def sout2 = new StringBuilder(), serr2 = new StringBuilder()
+proc = "oc get route ${sout} -o jsonpath={.spec.host}".execute()
+proc.consumeProcessOutput(sout2, serr2)
+proc.waitForOrKill(3000)
+println "out> $sout2 err> $serr2"
+
+def jlc = jenkins.model.JenkinsLocationConfiguration.get()
+jlc.setUrl("https://" + sout2.toString().trim())
+
+println("Configuring container cap for k8s, so pipelines won't hang when booting up slaves")
+
+try{
+    def kc = Jenkins.instance.clouds.get(0)
+
+    println "cloud found: ${Jenkins.instance.clouds}"
+
+    kc.setContainerCapStr("100")
+}
+finally {
+    //if we don't null kc, jenkins will try to serialise k8s objects and that will fail, so we won't see actual error
+    kc = null
+}


### PR DESCRIPTION
#### What is this PR About?
Add a script to set the jenkins root URL to custom hygieia jenkins master

#### How do we test this?

1. Run the applier playbook, per README
2. Apply and run the following pipeline, ensuring it outputs the route of the jenkins master, and not `null`

```
kind: "BuildConfig"
  apiVersion: "v1"
  metadata:
    name: my-pipeline
  spec:
    strategy:
      jenkinsPipelineStrategy:
        jenkinsfile: |-
          echo "Jenkins URL: ${env.JENKINS_URL}"
```

cc: @redhat-cop/containerize-it @pcarney8 
