### PR TITLE
Add '.py' to invocation of zap-baseline script.

### DIFF
--- a/jenkins-slaves/jenkins-slave-zap/README.md
+++ b/jenkins-slaves/jenkins-slave-zap/README.md
@@ -8,7 +8,7 @@ Provides a docker image of the zap runtime for use as a Jenkins slave. The publi
 
 ## Run local
 
-For local running and experimentation run `docker run -i -t jenkins-slave-zap /bin/bash` and have a play once inside the container. To check the zap runtime run `/zap/zap-baseline -r index.html -t http//<url-to-test>`
+For local running and experimentation run `docker run -i -t jenkins-slave-zap /bin/bash` and have a play once inside the container. To check the zap runtime run `/zap/zap-baseline.py -r index.html -t http//<url-to-test>`
 
 ## Build in OpenShift
 


### PR DESCRIPTION
#### What is this PR About?

When I started the docker container, it was not configured to run python scripts automagically. Adding '.py' to the invocation of the zap-baseline script fixed this. It should not negatively impact anyone.

#### How do we test this?

After building the docker image, start it. Then run /zap/zap-baseline.py. You should see the help message.

cc: @redhat-cop/containerize-it
