### PR TITLE
Adding Zalenium (Containerised Selenium Grid)

### DIFF
--- a/zalenium/.applier/group_vars/seed-hosts.yml
+++ b/zalenium/.applier/group_vars/seed-hosts.yml
@@ -3,11 +3,13 @@ namespace: zalenium
 app_name: zalenium
 
 app_params:
-  ETC_VOL_SIZE: 100Mi
-  GITLAB_DATA_VOL_SIZE: 5Gi
-  POSTGRESQL_VOL_SIZE: 5Gi
-  GITLAB_ROOT_PASSWORD: secretpassword
-  NAMESPACE: "{{ namespace }}"
+  ZALENIUM_MEMORY_LIMIT: "1000m"
+  ZALENIUM_CPU_LIMIT: "2Gi"
+  VIDEOS_STORAGE_SIZE: "10G"
+  SLAVE_CPU_REQUEST: "100m"
+  SLAVE_CPU_LIMIT: "1000m"
+  SLAVE_MEMORY_REQUEST: "1Gi"
+  SLAVE_MEMORY_LIMIT: "2Gi"
 
 
 openshift_cluster_content:

--- a/zalenium/.applier/group_vars/seed-hosts.yml
+++ b/zalenium/.applier/group_vars/seed-hosts.yml
@@ -1,0 +1,29 @@
+---
+namespace: zalenium
+app_name: zalenium
+
+app_params:
+  ETC_VOL_SIZE: 100Mi
+  GITLAB_DATA_VOL_SIZE: 5Gi
+  POSTGRESQL_VOL_SIZE: 5Gi
+  GITLAB_ROOT_PASSWORD: secretpassword
+  NAMESPACE: "{{ namespace }}"
+
+
+openshift_cluster_content:
+- object: Environment Setup
+  content:
+  - name: Create Projects
+    template: "{{ inventory_dir }}/../.openshift/templates/projects.yml"
+    action: create
+    params_from_vars:
+      NAMESPACE: "{{ namespace }}"
+      NAMESPACE_DISPLAY_NAME: "{{ namespace }}"
+    tags:
+      - project
+- object: deployments
+  content:
+  - name: Zalenium
+    template: "{{ inventory_dir }}/../.openshift/templates/zalenium-deployment.yml"
+    params_from_vars: "{{ app_params }}"
+    namespace: "{{ namespace }}"

--- a/zalenium/.applier/group_vars/seed-hosts.yml
+++ b/zalenium/.applier/group_vars/seed-hosts.yml
@@ -3,8 +3,8 @@ namespace: zalenium
 app_name: zalenium
 
 app_params:
-  ZALENIUM_MEMORY_LIMIT: "1000m"
-  ZALENIUM_CPU_LIMIT: "2Gi"
+  ZALENIUM_MEMORY_LIMIT: "2Gi"
+  ZALENIUM_CPU_LIMIT: "1000m"
   VIDEOS_STORAGE_SIZE: "10G"
   SLAVE_CPU_REQUEST: "100m"
   SLAVE_CPU_LIMIT: "1000m"

--- a/zalenium/.applier/hosts
+++ b/zalenium/.applier/hosts
@@ -1,0 +1,2 @@
+[seed-hosts]
+localhost ansible_connection=local

--- a/zalenium/.openshift/templates/projects.yml
+++ b/zalenium/.openshift/templates/projects.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Template
+labels:
+  template: project-template
+metadata:
+  name: project-template
+objects:
+- kind: ProjectRequest
+  apiVersion: v1
+  metadata:
+    name: ${NAMESPACE}
+    creationTimestamp: null
+  displayName: ${DISPLAY_NAME}
+parameters:
+- name: NAMESPACE
+- name: DISPLAY_NAME

--- a/zalenium/.openshift/templates/zalenium-deployment.yml
+++ b/zalenium/.openshift/templates/zalenium-deployment.yml
@@ -56,6 +56,10 @@ objects:
     name: zalenium
   spec:
     replicas: 1
+    strategy:
+      recreateParams:
+        timeoutSeconds: 600
+      type: Recreate
     template:
       metadata:
         labels:
@@ -105,6 +109,9 @@ objects:
               - name: CONTEXT_PATH
                 value: ${CONTEXT_PATH}
             resources:
+              requests:
+                cpu: ${ZALENIUM_CPU_REQUEST}
+                memory: "${ZALENIUM_MEMORY_REQUEST}"
               limits:
                 cpu: ${ZALENIUM_CPU_LIMIT}
                 memory: "${ZALENIUM_MEMORY_LIMIT}"
@@ -145,14 +152,22 @@ objects:
         storage: ${VIDEOS_STORAGE_SIZE}
 
 parameters:
+- name: ZALENIUM_MEMORY_REQUEST
+  description: Min Memory for Zalenium Zalenium (Selenium Grid) master
+  required: true
+  value: "500Mi"
+- name: ZALENIUM_CPU_REQUEST
+  description: Min CPU for Zalenium (Selenium Grid) master
+  required: true
+  value: "100m"
 - name: ZALENIUM_MEMORY_LIMIT
   description: Max Memory for Zalenium Zalenium (Selenium Grid) master
   required: true
-  value: "1000m"
+  value: "2Gi"
 - name: ZALENIUM_CPU_LIMIT
   description: Max CPU for Zalenium (Selenium Grid) master
   required: true
-  value: "2Gi"
+  value: "1000m"
 - name: SLAVE_CPU_REQUEST
   description: Minium CPU for Zalenium slaves
   required: true

--- a/zalenium/.openshift/templates/zalenium-deployment.yml
+++ b/zalenium/.openshift/templates/zalenium-deployment.yml
@@ -1,0 +1,234 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: zalenium
+metadata:
+  annotations:
+    description: zalenium deployment
+    tags: selenium,selenium-grid,zalenium
+  name: zalenium
+objects:
+- apiVersion: v1
+  kind: Role
+  metadata:
+    name: zalenium-role
+  rules:
+  - verbs: ['create','list','get','delete','watch']         
+    resources: ['pods']
+  - verbs: ['create', 'get']         
+    resources: ['pods/exec']    
+
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: zalenium
+
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: RoleBinding
+  metadata:
+    name: zalenium-role-binding
+  roleRef:
+    kind: Role
+    name: zalenium-role
+  subjects:
+  - kind: ServiceAccount
+    name: zalenium            
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: zalenium
+    name: zalenium
+  spec:
+    ports:
+    - name: zalenium
+      port: 4444
+      protocol: TCP
+      targetPort: 4444
+    selector:
+      app: zalenium
+      role: grid
+    type: ClusterIP
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: zalenium
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: zalenium
+          role: grid
+      spec:
+        containers:
+          - name: zalenium
+            image: ${IMAGE}
+            args:
+              - start
+            env:
+              - name: ZALENIUM_KUBERNETES_CPU_REQUEST
+                value: ${CPU_REQUEST}
+              - name: ZALENIUM_KUBERNETES_CPU_LIMIT
+                value: ${CPU_LIMIT}
+              - name: ZALENIUM_KUBERNETES_MEMORY_REQUEST
+                value: ${MEMORY_REQUEST}
+              - name: ZALENIUM_KUBERNETES_MEMORY_LIMIT
+                value: ${MEMORY_LIMIT}
+              - name: DESIRED_CONTAINERS
+                value: ${DESIRED_CONTAINERS}
+              - name: MAX_DOCKER_SELENIUM_CONTAINERS
+                value: ${MAX_DOCKER_SELENIUM_CONTAINERS}
+              - name: SELENIUM_IMAGE_NAME
+                value: ${SELENIUM_IMAGE_NAME}
+              - name: VIDEO_RECORDING_ENABLED
+                value: ${VIDEO_RECORDING_ENABLED}
+              - name: SCREEN_WIDTH
+                value: ${SCREEN_WIDTH}
+              - name: SCREEN_HEIGHT
+                value: ${SCREEN_HEIGHT}
+              - name: MAX_TEST_SESSIONS
+                value: ${MAX_TEST_SESSIONS}
+              - name: NEW_SESSION_WAIT_TIMEOUT
+                value: ${NEW_SESSION_WAIT_TIMEOUT}
+              - name: DEBUG_ENABLED
+                value: ${DEBUG_ENABLED}
+              - name: SEND_ANONYMOUS_USAGE_INFO
+                value: ${SEND_ANONYMOUS_USAGE_INFO}
+              - name: TZ
+                value: ${TZ}
+              - name: KEEP_ONLY_FAILED_TESTS
+                value: ${KEEP_ONLY_FAILED_TESTS}
+              - name: RETENTION_PERIOD
+                value: ${RETENTION_PERIOD}
+              - name: CONTEXT_PATH
+                value: ${CONTEXT_PATH}
+            resources:
+              request:
+                cpu: 500m
+                memory: "500Mi"
+              limits:
+                cpu: "1000m"
+                memory: "2Gi"
+            ports:
+              - containerPort: 4444
+                protocol: TCP
+            volumeMounts:
+              - name: zalenium-videos
+                mountPath: /home/seluser/videos  
+        volumes:
+            - name: zalenium-videos
+              persistentVolumeClaim:
+                claimName: zalenium-videos
+        serviceAccountName: zalenium
+        serviceAccount: zalenium
+
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      haproxy.router.openshift.io/timeout: 15m
+    name: zalenium
+  spec:
+    to:
+      kind: Service
+      name: zalenium
+
+
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: zalenium-videos
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${VIDEOS_STORAGE_SIZE}
+
+parameters:
+- name: CPU_REQUEST
+  description: Minium CPU for Zalenium slaves
+  required: true
+  value: "100m"
+- name: CPU_LIMIT
+  description: Max CPU for Zalenium slaves
+  required: true
+  value: "1000m"
+- name: MEMORY_REQUEST
+  description: Minimum Memory for Zalenium slaves
+  required: true
+  value: "1Gi"
+- name: MEMORY_LIMIT
+  description: Max Memory for Zalenium slaves
+  required: true
+  value: "2Gi"
+- name: VIDEOS_STORAGE_SIZE
+  description: Max Memory for Zalenium slaves
+  required: true
+  value: "10G"
+- name: DATA_STORAGE_SIZE
+  description: Max Memory for Zalenium slaves
+  required: true
+  value: "2G"
+- name: IMAGE
+  required: true
+  description: Dockerimage location:tag
+  value: dosel/zalenium:3
+- name: DESIRED_CONTAINERS
+  required: true
+  description: Number of containers created on startup.
+  value: "0"
+- name: MAX_DOCKER_SELENIUM_CONTAINERS
+  required: true
+  description: Maximum number of docker-selenium containers running at the same time.
+  value: "10"
+- name: SELENIUM_IMAGE_NAME
+  required: true
+  description: Enables overriding of the Docker selenium image to use.
+  value: "elgalu/selenium"
+- name: VIDEO_RECORDING_ENABLED
+  required: true
+  description: Sets if video is recorded in every test.
+  value: "true"
+- name: SCREEN_WIDTH
+  required: true
+  description: Sets the screen width.
+  value: "1920"
+- name: SCREEN_HEIGHT
+  required: true
+  description: Sets the screen height.
+  value: "1080"
+- name: MAX_TEST_SESSIONS
+  required: true
+  description: Maximum amount of tests executed per container.
+  value: "1"
+- name: NEW_SESSION_WAIT_TIMEOUT
+  required: true
+  description: Time in ms that a session will be kept in the queue before it timesout while waiting for a node to be available.
+  value: "600000"
+- name: DEBUG_ENABLED
+  required: true
+  description: Enables LogLevel.FINE.
+  value: "false"
+- name: SEND_ANONYMOUS_USAGE_INFO
+  required: true
+  description: Send anonymous usage info
+  value: "false"
+- name: TZ
+  required: true
+  description: Sets the time zone in the containers.
+  value: "Etc/UTC"
+- name: KEEP_ONLY_FAILED_TESTS
+  required: true
+  description: Keeps only failed tests on the dashboard (you need to send a cookie with the test result).
+  value: "false"
+- name: RETENTION_PERIOD
+  required: true
+  description: Number of day's a testentry should be kept in dashboard before cleanup. Note, You need to manually push the Cleanup button or create a cronjob 
+  value: "3"
+- name: CONTEXT_PATH
+  required: true
+  description: Context path for incoming HTTP traffic from a Route
+  value: "/"

--- a/zalenium/.openshift/templates/zalenium-deployment.yml
+++ b/zalenium/.openshift/templates/zalenium-deployment.yml
@@ -106,7 +106,7 @@ objects:
                 value: ${CONTEXT_PATH}
             resources:
               limits:
-                cpu: {ZALENIUM_CPU_LIMIT}
+                cpu: ${ZALENIUM_CPU_LIMIT}
                 memory: "${ZALENIUM_MEMORY_LIMIT}"
             ports:
               - containerPort: 4444

--- a/zalenium/.openshift/templates/zalenium-deployment.yml
+++ b/zalenium/.openshift/templates/zalenium-deployment.yml
@@ -69,13 +69,13 @@ objects:
               - start
             env:
               - name: ZALENIUM_KUBERNETES_CPU_REQUEST
-                value: ${CPU_REQUEST}
+                value: ${SLAVE_CPU_REQUEST}
               - name: ZALENIUM_KUBERNETES_CPU_LIMIT
-                value: ${CPU_LIMIT}
+                value: ${SLAVE_CPU_LIMIT}
               - name: ZALENIUM_KUBERNETES_MEMORY_REQUEST
-                value: ${MEMORY_REQUEST}
+                value: ${SLAVE_MEMORY_REQUEST}
               - name: ZALENIUM_KUBERNETES_MEMORY_LIMIT
-                value: ${MEMORY_LIMIT}
+                value: ${SLAVE_MEMORY_LIMIT}
               - name: DESIRED_CONTAINERS
                 value: ${DESIRED_CONTAINERS}
               - name: MAX_DOCKER_SELENIUM_CONTAINERS
@@ -105,12 +105,9 @@ objects:
               - name: CONTEXT_PATH
                 value: ${CONTEXT_PATH}
             resources:
-              request:
-                cpu: 500m
-                memory: "500Mi"
               limits:
-                cpu: "1000m"
-                memory: "2Gi"
+                cpu: {ZALENIUM_CPU_LIMIT}
+                memory: "${ZALENIUM_MEMORY_LIMIT}"
             ports:
               - containerPort: 4444
                 protocol: TCP
@@ -148,19 +145,27 @@ objects:
         storage: ${VIDEOS_STORAGE_SIZE}
 
 parameters:
-- name: CPU_REQUEST
+- name: ZALENIUM_MEMORY_LIMIT
+  description: Max Memory for Zalenium Zalenium (Selenium Grid) master
+  required: true
+  value: "1000m"
+- name: ZALENIUM_CPU_LIMIT
+  description: Max CPU for Zalenium (Selenium Grid) master
+  required: true
+  value: "2Gi"
+- name: SLAVE_CPU_REQUEST
   description: Minium CPU for Zalenium slaves
   required: true
   value: "100m"
-- name: CPU_LIMIT
+- name: SLAVE_CPU_LIMIT
   description: Max CPU for Zalenium slaves
   required: true
   value: "1000m"
-- name: MEMORY_REQUEST
+- name: SLAVE_MEMORY_REQUEST
   description: Minimum Memory for Zalenium slaves
   required: true
   value: "1Gi"
-- name: MEMORY_LIMIT
+- name: SLAVE_MEMORY_LIMIT
   description: Max Memory for Zalenium slaves
   required: true
   value: "2Gi"
@@ -168,10 +173,6 @@ parameters:
   description: Max Memory for Zalenium slaves
   required: true
   value: "10G"
-- name: DATA_STORAGE_SIZE
-  description: Max Memory for Zalenium slaves
-  required: true
-  value: "2G"
 - name: IMAGE
   required: true
   description: Dockerimage location:tag

--- a/zalenium/README.md
+++ b/zalenium/README.md
@@ -1,0 +1,37 @@
+## Prerequisites
+
+The following prerequisites must be met prior to beginning to deploy [Zalenium](https://opensource.zalando.com/zalenium/) (A container based Selenium Grid)
+
+* 1 [Persistent Volumes](https://docs.openshift.com/container-platform/latest/architecture/additional_concepts/storage.html) or a cluster that supports [dynamic provisioning with a default StorageClass](https://docs.openshift.com/container-platform/latest/install_config/storage_examples/storage_classes_dynamic_provisioning.html)
+* OpenShift Command Line Tool
+* [Openshift Applier](https://github.com/redhat-cop/openshift-applier/) to deploy GitLab CE. As a result you'll need to have [ansible installed](http://docs.ansible.com/ansible/latest/intro_installation.html)
+
+
+### Environment Setup
+
+1. Clone this repository: `git clone https://github.com/redhat-cop/containers-quickstarts`
+2. `cd containers-quickstarts/zalenium`
+3. Run `ansible-galaxy install -r requirements.yml --roles-path=galaxy`
+4. Login to OpenShift: `oc login -u <username> https://master.example.com:8443`
+
+### Deploy Zalenium
+
+Run the openshift-applier to create the `zalenium` project and deploy required objects
+```
+ansible-playbook -i .applier galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml
+```
+
+### Next steps
+
+Access your Zalenium:
+* Life Dashboard of ongoing tests:
+http://zalenium-zalenium.apps.example.com/grid/admin/live?refresh=20
+* Recordings of previous tests:
+http://zalenium-zalenium.apps.example.com/dashboard/#
+
+Run simple test from your local machine:
+1. Setup [Protractor](https://www.protractortest.org/#/tutorial#setup): `npm install -g protractor`
+2. Get into test directory `cd example-tests/protractor`
+3. Edit the `conf.js` -file to point to your own Zalenium instance
+4. Inspect the `simple-test.js` -file. It will just quickly access Angular.Js -website and make a post to their TODO example.
+5. Run the tests with: `protractor conf.js`

--- a/zalenium/README.md
+++ b/zalenium/README.md
@@ -24,7 +24,7 @@ ansible-playbook -i .applier galaxy/openshift-applier/playbooks/openshift-cluste
 ### Next steps
 
 Access your Zalenium:
-* Life Dashboard of ongoing tests:
+* Live Dashboard of ongoing tests:
 http://zalenium-zalenium.apps.example.com/grid/admin/live?refresh=20
 * Recordings of previous tests:
 http://zalenium-zalenium.apps.example.com/dashboard/#

--- a/zalenium/example-tests/protractor/conf.js
+++ b/zalenium/example-tests/protractor/conf.js
@@ -1,0 +1,10 @@
+exports.config = {
+  seleniumAddress: 'http://zalenium-zalenium.apps.example.com/wd/hub',
+  specs: ['simple-test.js'],
+  allScriptsTimeout: 11000,
+  multiCapabilities: [{
+    browserName: 'firefox'
+  }, {
+    browserName: 'chrome'
+  }]
+};

--- a/zalenium/example-tests/protractor/simple-test.js
+++ b/zalenium/example-tests/protractor/simple-test.js
@@ -1,0 +1,18 @@
+describe('angularjs homepage todo list', function() {
+  it('should add a todo', function() {
+    browser.get('https://angularjs.org');
+
+    element(by.model('todoList.todoText')).sendKeys('write first protractor test');
+    element(by.css('[value="add"]')).click();
+
+    var todoList = element.all(by.repeater('todo in todoList.todos'));
+    expect(todoList.count()).toEqual(3);
+    expect(todoList.get(2).getText()).toEqual('write first protractor test');
+
+    // You wrote your first test, cross it off the list
+    todoList.get(2).element(by.css('input')).click();
+    var completedAmount = element.all(by.css('.done-true'));
+    expect(completedAmount.count()).toEqual(2);
+  });
+});
+

--- a/zalenium/requirements.yml
+++ b/zalenium/requirements.yml
@@ -1,0 +1,8 @@
+# This is the Ansible Galaxy requirements file to pull in the correct roles
+# to support the operation of CASL provisioning/runs.
+
+# From 'openshift-applier'
+- name: openshift-applier
+  scm: git
+  src: https://github.com/redhat-cop/openshift-applier
+  version: v2.0.6


### PR DESCRIPTION
#### What is this PR About?
This adds Zalenium deployment. Current Selenium Grid example under [container-pipelines](https://github.com/redhat-cop/container-pipelines/tree/master/cucumber-selenium-grid) uses privileged ClusterRoles that are not always available. Also the upstream [Zelenium](https://opensource.zalando.com/zalenium/) uses Helm Charts that we currently don't have always available.

Once this PR is merged I will update the Selenium Grid example on container-pipelines.

#### How do we test this?
Follow instructions on README.md how to deploy and run simple test from your local machine.

cc: @redhat-cop/containerize-it
