### PR TITLE
Adding build-monitor-plugin to custom jenkins master build

### DIFF
--- a/jenkins-masters/hygieia-plugin/.applier/group_vars/seed-hosts.yml
+++ b/jenkins-masters/hygieia-plugin/.applier/group_vars/seed-hosts.yml
@@ -1,6 +1,8 @@
 namespace: jenkins-hygieia
 hygieia_url:
 hygieia_token:
+source_code_url: https://github.com/redhat-cop/containers-quickstarts.git
+source_code_ref: master
 
 openshift_cluster_content:
 - object: Environment Setup
@@ -22,6 +24,9 @@ openshift_cluster_content:
       - build-hygieia-plugin
   - name: Jenkins Master Image
     template: "{{ inventory_dir }}/../.openshift/templates/jenkins-s2i.yml"
+    params_from_vars:
+      SOURCE_CODE_URL: "{{ source_code_url }}"
+      SOURCE_CODE_REF: "{{ source_code_ref }}"
     namespace: "{{ namespace }}"
     tags:
       - build

--- a/jenkins-masters/hygieia-plugin/.applier/group_vars/seed-hosts.yml
+++ b/jenkins-masters/hygieia-plugin/.applier/group_vars/seed-hosts.yml
@@ -3,6 +3,7 @@ hygieia_url:
 hygieia_token:
 source_code_url: https://github.com/redhat-cop/containers-quickstarts.git
 source_code_ref: master
+jenkins_memory_limit: 1024Mi
 
 openshift_cluster_content:
 - object: Environment Setup
@@ -41,5 +42,6 @@ openshift_cluster_content:
       NAMESPACE: "{{ namespace }}"
       HYGIEIA_API_URL: "{{ hygieia_url }}"
       HYGIEIEA_API_TOKEN: "{{ hygieia_token }}"
+      MEMORY_LIMIT: "{{ jenkins_memory_limit }}"
     tags:
       - deploy

--- a/jenkins-masters/hygieia-plugin/.openshift/templates/jenkins-ephemeral.yml
+++ b/jenkins-masters/hygieia-plugin/.openshift/templates/jenkins-ephemeral.yml
@@ -208,7 +208,7 @@ parameters:
 - description: Maximum amount of memory the container can use.
   displayName: Memory Limit
   name: MEMORY_LIMIT
-  value: 512Mi
+  value: 1024Mi
 - description: The OpenShift Namespace where the Jenkins ImageStream resides.
   displayName: Jenkins ImageStream Namespace
   name: NAMESPACE

--- a/jenkins-masters/hygieia-plugin/.openshift/templates/jenkins-s2i.yml
+++ b/jenkins-masters/hygieia-plugin/.openshift/templates/jenkins-s2i.yml
@@ -48,7 +48,7 @@ objects:
           kind: ImageStreamTag
           name: hygieia-plugin:latest
         paths:
-        - destinationDir: "jenkins-masters/hygieia-plugin/plugins"
+        - destinationDir: jenkins-masters/hygieia-plugin/plugins
           sourcePath: /tmp/src/target/hygieia-publisher.hpi
       type: Image
     strategy:

--- a/jenkins-masters/hygieia-plugin/plugins.txt
+++ b/jenkins-masters/hygieia-plugin/plugins.txt
@@ -1,0 +1,1 @@
+build-monitor-plugin


### PR DESCRIPTION
#### What is this PR About?
Apparently the 3.11 jenkins is missing the build-monitor-plugin, which is needed fro the groovy script that sets the root URL. I'm adding it back in.

#### How do we test this?
Spin up the hygieia jenkins quickstart, stand up a pipeline that uses ${JENKINS_URL} and make sure it works.

cc: @redhat-cop/containerize-it
