### PR TITLE
Upgrade openshfit-applier to v2.0.8

### DIFF
--- a/build-docker-generic/requirements.yml
+++ b/build-docker-generic/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/build-s2i-gows/requirements.yml
+++ b/build-s2i-gows/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/build-s2i-jekyll/requirements.yml
+++ b/build-s2i-jekyll/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/build-s2i-liberty/requirements.yml
+++ b/build-s2i-liberty/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/build-s2i-play/requirements.yml
+++ b/build-s2i-play/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/gitlab-ce/requirements.yml
+++ b/gitlab-ce/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/gogs/requirements.yml
+++ b/gogs/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/hoverfly/requirements.yml
+++ b/hoverfly/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/jenkins-masters/hygieia-plugin/requirements.yml
+++ b/jenkins-masters/hygieia-plugin/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/jenkins-slaves/requirements.yml
+++ b/jenkins-slaves/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/mongodb/requirements.yml
+++ b/mongodb/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/rabbitmq/requirements.yml
+++ b/rabbitmq/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/sonarqube/requirements.yml
+++ b/sonarqube/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/tool-box/requirements.yml
+++ b/tool-box/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8

--- a/zalenium/requirements.yml
+++ b/zalenium/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.8


### PR DESCRIPTION
This addresses the issue with "oc process" without the "-f" flag when running the task "Create OpenShift objects based on template"

#### What is this PR About?
The openshift-applier version 2.06 is causing the following issue for some of the playbooks (MongoDB, RabbitMQ and GitLab at least):

```
TASK [openshift-applier : Create OpenShift objects based on template with params for 'Environment Setup : Create Projects'] ********************************************************************************
failed: [localhost] (item={'oc_path': ''}) => {"changed": true, "cmd": "oc process   https://raw.githubusercontent.com/redhat-cop/cluster-lifecycle/v3.9.0/files/projectrequest/template.yml   --param='NAMESPACE=rabbitmq' --param='NAMESPACE_DISPLAY_NAME=rabbitmq'  --ignore-unknown-parameters | oc create  -f - ", "delta": "0:00:00.155317", "end": "2019-02-18 16:32:36.001178", "failed_when_result": true, "msg": "non-zero return code", "oc_param_file_item": {"oc_path": ""}, "rc": 1, "start": "2019-02-18 16:32:35.845861", "stderr": "error: invalid argument \"https://raw.githubusercontent.com/redhat-cop/cluster-lifecycle/v3.9.0/files/projectrequest/template.yml\"\nerror: no objects passed to create", "stderr_lines": ["error: invalid argument \"https://raw.githubusercontent.com/redhat-cop/cluster-lifecycle/v3.9.0/files/projectrequest/template.yml\"", "error: no objects passed to create"], "stdout": "", "stdout_lines": []}
```

This is due to the lack of the "-f" flag in the "oc process" command.

#### How do we test this?

- Run the RabbitMQ quickstart.

cc: @redhat-cop/containerize-it
