### PR TITLE
Update oc and ansible versions, fixes #166

### DIFF
--- a/tool-box/Dockerfile
+++ b/tool-box/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 
-ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.10.86/linux/oc.tar.gz
+ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.11.0-0.32.0/linux/oc.tar.gz
 ENV HOME /home/tool-box
 
 RUN dnf -y update && \
@@ -10,7 +10,7 @@ RUN dnf -y update && \
     curl $OC_CLIENT_MIRROR | tar -C /usr/local/bin/ -xzf - && \
     mkdir -m 775 $HOME && \
     chmod 775 /etc/passwd && \
-    pip install git+https://github.com/ansible/ansible.git@stable-2.5
+    pip install git+https://github.com/ansible/ansible.git@stable-2.6
 
 WORKDIR $HOME
 

--- a/tool-box/README.md
+++ b/tool-box/README.md
@@ -6,8 +6,8 @@ This container exists to help folks that can't install ansible, git or other nec
 
 ## What's in the box?
 
-- `oc` version 3.9.14
-- `ansible` 2.5 (stable from `pip`)
+- `oc` version 3.11.0-0.32.0
+- `ansible` 2.6 (stable from `pip`)
 - `git`
 - `tree`
 - `unzip`


### PR DESCRIPTION
#### What is this PR About?
Update to latest version of `oc` and latest `ansible 2.6` to address #166 

#### How do we test this?
Follow instructions in the README for building and running the tool-box container.

cc: @redhat-cop/containerize-it
