### PR TITLE
adding post hook to sonarqube deployment template for jenkins

### DIFF
--- a/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
+++ b/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
@@ -153,6 +153,15 @@ objects:
       activeDeadlineSeconds: 21600
       recreateParams:
         timeoutSeconds: 600
+        post:
+          execNewPod:
+            command:
+            - /bin/sh
+            - -c
+            - sleep 30 && curl http://admin:admin@sonarqube:9000/api/webhooks/create
+              -X POST -d "name=jenkins&url=http://jenkins/sonarqube-webhook/"
+            containerName: sonarqube
+          failurePolicy: Abort
       resources:
         limits:
           cpu: "2"


### PR DESCRIPTION
#### What is this PR About?
Adding a post hook to the sonarqube deployment so that in our builds jenkins can be notified on when the quality gate is completed.

#### How do we test this?
Deploy sonarqube and through the admin portal under webhooks you will see the 'jenkins' webhook created.

cc: @redhat-cop/containerize-it

@sherl0cks 
