### PR TITLE
Issue 191   remove scl enable from npm slave

### DIFF
--- a/jenkins-slaves/jenkins-slave-npm/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-npm/Dockerfile
@@ -20,6 +20,9 @@ RUN INSTALL_PKGS="nodejs redhat-lsb libXScrnSaver xdg-utils liberation-fonts" &&
     yum clean all -y && \
     rm -rf /var/cache/yum && \
     npm install --unsafe-perm -g npm-audit-html npm-audit-ci-wrapper sonar-scanner || cat /home/jenkins/.npm/_logs/*-debug.log && \
-    sonar-scanner || echo
+    sonar-scanner && \
+    chown root:root /home/jenkins -R && \
+    chmod 775 /home/jenkins/.config -R && \
+    chmod 775 /home/jenkins/.npm -R
 
 USER 1001

--- a/jenkins-slaves/jenkins-slave-npm/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-npm/Dockerfile
@@ -20,7 +20,6 @@ RUN INSTALL_PKGS="nodejs redhat-lsb libXScrnSaver xdg-utils liberation-fonts" &&
     yum clean all -y && \
     rm -rf /var/cache/yum && \
     npm install --unsafe-perm -g npm-audit-html npm-audit-ci-wrapper sonar-scanner || cat /home/jenkins/.npm/_logs/*-debug.log && \
-    sonar-scanner && \
     chown root:root /home/jenkins -R && \
     chmod 775 /home/jenkins/.config -R && \
     chmod 775 /home/jenkins/.npm -R

--- a/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
@@ -28,6 +28,9 @@ RUN INSTALL_PKGS="npm nss_wrapper redhat-lsb libXScrnSaver xdg-utils google-chro
       $INSTALL_PKGS && \
     yum clean all -y && \
     rm -rf /var/cache/yum && \
-    npm install --unsafe-perm -g npm-audit-html npm-audit-ci-wrapper sonar-scanner
+    npm install --unsafe-perm -g npm-audit-html npm-audit-ci-wrapper sonar-scanner && \
+    chown root:root /home/jenkins -R && \
+    chmod 775 /home/jenkins/.config -R && \
+    chmod 775 /home/jenkins/.npm -R
 
 USER 1001

--- a/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
@@ -1,5 +1,5 @@
 #invoke npm in jenkinsfile: sh "scl enable rh-nodejs6 'npm run build'"
-FROM openshift3/jenkins-slave-base-rhel7:v3.11
+FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 
 LABEL com.redhat.component="jenkins-slave-nodejs-rhel7-docker" \
       name="openshift3/jenkins-slave-nodejs-rhel7" \
@@ -17,7 +17,7 @@ ENV NODEJS_VERSION=10 \
 
 ADD src/google-chrome.repo /etc/yum.repos.d/
 
-RUN INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper redhat-lsb libXScrnSaver xdg-utils google-chrome-stable" && \
+RUN INSTALL_PKGS="npm nss_wrapper redhat-lsb libXScrnSaver xdg-utils google-chrome-stable" && \
     yum install -y --setopt=tsflags=nodocs \
       --disablerepo=* \
       --enablerepo=rhel-7-server-rpms \
@@ -28,7 +28,6 @@ RUN INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-n
       $INSTALL_PKGS && \
     yum clean all -y && \
     rm -rf /var/cache/yum && \
-    npm install -g npm-audit-html npm-audit-ci-wrapper sonar-scanner && \
-    sonar-scanner || echo
+    npm install --unsafe-perm -g npm-audit-html npm-audit-ci-wrapper sonar-scanner
 
 USER 1001

--- a/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-npm/Dockerfile.rhel7
@@ -15,7 +15,6 @@ ENV NODEJS_VERSION=10 \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
     CHROME_BIN=/bin/google-chrome
 
-COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 ADD src/google-chrome.repo /etc/yum.repos.d/
 
 RUN INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper redhat-lsb libXScrnSaver xdg-utils google-chrome-stable" && \

--- a/jenkins-slaves/jenkins-slave-npm/README.md
+++ b/jenkins-slaves/jenkins-slave-npm/README.md
@@ -4,6 +4,12 @@ Provides a docker image of the nodejs v8 runtime with npm for use as a Jenkins s
 ## Build local
 `docker build -t jenkins-slave-npm .`
 
+Or for Red Hat Enterprise Linux:
+
+`docker build -t jenkins-slave-npm -f Dockerfile.rhel7 .`
+
+### NOTE: To build the RHEL image you will need to have access to the `rhel-7-server-rhoar-nodejs-10-rpms` repository
+
 ## Run local
 For local running and experimentation run `docker run -i -t jenkins-slave-npm /bin/bash` and have a play once inside the container.
 


### PR DESCRIPTION
#### What is this PR About?
Remove the obsolete `COPY contrib/bin/scl_enable /usr/local/bin/scl_enable`
Resolves #191 

#### How do we test this?
1. clone the repo
2. Checkout the branch
3. Change to `jenkins-slaves/jenkins-slave-npm`
4. Run `docker build -t test-npm -f Dockerfile.rhel .`
5. Run resultant container and ensure NPM works: `npm --version`

cc: @redhat-cop/day-in-the-life @oybed @etsauer @haithamshahin333 @sherl0cks 
