### PR TITLE
Update Jenkins Maven Slave to Newer Base Image

### DIFF
--- a/jenkins-slaves/jenkins-slave-mvn/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-mvn/Dockerfile
@@ -1,2 +1,2 @@
-FROM openshift/jenkins-slave-maven-rhel7:v3.11
+FROM registry.access.redhat.com/openshift3/jenkins-agent-maven-35-rhel7
 ADD settings.xml $HOME/.m2/settings.xml

--- a/jenkins-slaves/jenkins-slave-mvn/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-mvn/Dockerfile
@@ -1,2 +1,2 @@
-FROM registry.access.redhat.com/openshift3/jenkins-agent-maven-35-rhel7
+FROM openshift3/jenkins-agent-maven-35-rhel7:latest
 ADD settings.xml $HOME/.m2/settings.xml

--- a/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
+++ b/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
@@ -153,6 +153,15 @@ objects:
       activeDeadlineSeconds: 21600
       recreateParams:
         timeoutSeconds: 600
+        post:
+          execNewPod:
+            command:
+            - /bin/sh
+            - -c
+            - sleep 30 && curl http://admin:admin@sonarqube:9000/api/webhooks/create
+              -X POST -d "name=jenkins&url=http://jenkins/sonarqube-webhook/"
+            containerName: sonarqube
+          failurePolicy: Abort
       resources:
         limits:
           cpu: "2"


### PR DESCRIPTION
#### What is this PR About?
Updating the base image to move away from the deprecated image: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift3/jenkins-slave-maven-rhel7/images/v3.6.173.0.146-3.

Additionally, this image will support using a newer version of the oc client @sabre1041 @sherl0cks .

cc: @redhat-cop/day-in-the-life
