### PR TITLE
Convert Dockerfile to use RHEL Jenkins base image

### DIFF
--- a/jenkins-slaves/jenkins-slave-ruby/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-base-centos7:v3.11
+FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 
 ENV RUBY_VERSION 2.4
 
@@ -12,9 +12,7 @@ It is simple, straight-forward, and extensible." \
   ENV=/opt/app-root/etc/scl_enable \
   PATH=$PATH:/home/jenkins/bin \
   PROMPT_COMMAND=". /opt/app-root/etc/scl_enable" \
-  HOME=/home/jenkins \
-  ORIGIN_CLIENT=https://mirror.openshift.com/pub/openshift-v3/clients/3.11.50/linux/oc.tar.gz
-
+  HOME=/home/jenkins
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
@@ -23,20 +21,20 @@ LABEL summary="$SUMMARY" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,ruby,ruby24,rh-ruby24" \
       com.redhat.component="rh-ruby24-docker" \
-      name="centos/ruby-24-centos7" \
+      name="ruby/ruby-24-rhel7" \
       version="2.4" \
       release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
-RUN yum install -y centos-release-scl && \
-    yum-config-manager --enable centos-sclo-rh-testing && \
-    INSTALL_PKGS="rh-ruby24 rh-ruby24-ruby-devel rh-ruby24-rubygem-rake rh-ruby24-rubygem-bundler rh-nodejs6 autoconf automake" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && rpm -V $INSTALL_PKGS && \
-    yum remove -y origin-clients && \
-    yum clean all -y
-
-RUN curl $ORIGIN_CLIENT | tar -C /usr/local/bin/ -xzf - && \
-    chmod +x /usr/local/bin/oc
+RUN INSTALL_PKGS="rh-ruby24 rh-ruby24-ruby-devel rh-ruby24-rubygem-rake rh-ruby24-rubygem-bundler rh-nodejs6 autoconf automake" && \
+    yum install -y --setopt=tsflags=nodocs \
+      --disablerepo=* \
+      --enablerepo=rhel-server-rhscl-7-rpms \
+      --enablerepo=rhel-7-server-extras-rpms \
+      --enablerepo=rhel-7-server-rpms \
+      $INSTALL_PKGS && rpm -V $INSTALL_PKGS && \
+    yum clean all -y && \
+    rm -rf /var/cache/yum
 
 # Copy extra files to the image.
 COPY ./root/ /

--- a/jenkins-slaves/jenkins-slave-ruby/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-ruby/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-base-centos7:v3.11
+FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
 
 ENV RUBY_VERSION 2.4
 
@@ -12,9 +12,7 @@ It is simple, straight-forward, and extensible." \
   ENV=/opt/app-root/etc/scl_enable \
   PATH=$PATH:/home/jenkins/bin \
   PROMPT_COMMAND=". /opt/app-root/etc/scl_enable" \
-  HOME=/home/jenkins \
-  ORIGIN_CLIENT=https://mirror.openshift.com/pub/openshift-v3/clients/3.11.50/linux/oc.tar.gz
-
+  HOME=/home/jenkins
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
@@ -23,20 +21,20 @@ LABEL summary="$SUMMARY" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,ruby,ruby24,rh-ruby24" \
       com.redhat.component="rh-ruby24-docker" \
-      name="centos/ruby-24-centos7" \
+      name="ruby/ruby-24-rhel7" \
       version="2.4" \
       release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
-RUN yum install -y centos-release-scl && \
-    yum-config-manager --enable centos-sclo-rh-testing && \
-    INSTALL_PKGS="rh-ruby24 rh-ruby24-ruby-devel rh-ruby24-rubygem-rake rh-ruby24-rubygem-bundler rh-nodejs6 autoconf automake" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && rpm -V $INSTALL_PKGS && \
-    yum remove -y origin-clients && \
-    yum clean all -y
-
-RUN curl $ORIGIN_CLIENT | tar -C /usr/local/bin/ -xzf - && \
-    chmod +x /usr/local/bin/oc
+RUN INSTALL_PKGS="rh-ruby24 rh-ruby24-ruby-devel rh-ruby24-rubygem-rake rh-ruby24-rubygem-bundler rh-nodejs6 autoconf automake" && \
+    yum install -y --setopt=tsflags=nodocs \
+      --disablerepo=* \
+      --enablerepo=rhel-server-rhscl-7-rpms \
+      --enablerepo=rhel-7-server-extras-rpms \
+      --enablerepo=rhel-7-server-rpms \
+      $INSTALL_PKGS && rpm -V $INSTALL_PKGS && \
+    yum clean all -y && \
+    rm -rf /var/cache/yum
 
 # Copy extra files to the image.
 COPY ./root/ /


### PR DESCRIPTION
#### What is this PR About?
- Replace the CentOS base jenkins image with a RHEL base image
- Update YUM installations to use RHEL repositories
- Use the built-in `oc` client from the Jenkins slave base image

Resolves #195 

#### How do we test this?
From a RHEL host with the appropriate repositories enabled and Docker-latest installed, run:

```
docker build -t jenkins-slave-ruby .
```

cc: @redhat-cop/day-in-the-life @etsauer @lpsantil @sabre1041 
