### PR TITLE
Added releasever

### DIFF
--- a/jenkins-slaves/.openshift/templates/jenkins-slave-image-mgmt-template.yml
+++ b/jenkins-slaves/.openshift/templates/jenkins-slave-image-mgmt-template.yml
@@ -69,3 +69,7 @@ parameters:
   name: CONTEXT_DIR
   required: false
   value: jenkins-slaves/jenkins-slave-image-mgmt
+- description: The RHEL releasever
+  name: RHEL_RELEASEVER
+  required: true
+  value: 7Server

--- a/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
@@ -11,9 +11,11 @@ LABEL com.redhat.component="jenkins-slave-image-mgmt" \
 USER root
 
 RUN INSTALL_PKGS="skopeo" && \
+    if [ -z $RHEL_RELEASEVER ] ; then RHEL_RELEASEVER=7Server ; fi && \
     yum install -y --setopt=tsflags=nodocs \
       --enablerepo=rhel-7-server-rpms \
       --enablerepo=rhel-7-server-extras-rpms \
+      --releasever=${RHEL_RELEASEVER} \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all


### PR DESCRIPTION
#### What is this PR About?
The PR adds the possibility to add the env RHEL_RELEASEVER to the jenkins-slave-image-mgmt to the template and Dockerfile

In some environment, the hosts which will run the build could be configured in satellite with the set-release option. With this ENV you can override the "7Server" default one

#### How do we test this?
- Setup a host with set-release (for example 7.6)
- Add the env "RHEL_RELEASEVER=7.6" to the buildconfig
it will work
without the env, it will use the default "7Server" and will fail

cc: @redhat-cop/day-in-the-life
