### PR TITLE
added GO_VERSION

### DIFF
--- a/jenkins-slaves/jenkins-slave-golang/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-golang/Dockerfile
@@ -1,6 +1,6 @@
 FROM openshift/jenkins-slave-base-centos7:v3.11
 
-ENV GO_VERSION=1.10.2 \
+ENV GO_VERSION_DEFAULT=1.10.2 \
     GOROOT=/usr/local/go \
     GOPATH=/usr/src/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
@@ -11,8 +11,9 @@ RUN curl -L -o /tmp/sonar-scanner.zip https://binaries.sonarsource.com/Distribut
     mv sonar-scanner-* sonar-scanner && \
     ln -s /opt/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner && \
     chmod 755 /usr/local/bin/sonar-scanner
-ADD https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz /usr/
-RUN mkdir -p /usr/src/go/src/redhat && \
+RUN if [ -z $GO_VERSION ] ; then GO_VERSION=${GO_VERSION_DEFAULT} ; fi && \
+    curl -L -o /usr/go${GO_VERSION}.linux-amd64.tar.gz https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
+    mkdir -p /usr/src/go/src/redhat && \
     tar -xzf /usr/go${GO_VERSION}.linux-amd64.tar.gz && \
     mv $(pwd)/go /usr/local/ && \
     go get -u github.com/golang/dep/cmd/dep && \

--- a/jenkins-slaves/jenkins-slave-golang/Dockerfile.rhel7
+++ b/jenkins-slaves/jenkins-slave-golang/Dockerfile.rhel7
@@ -9,7 +9,7 @@ LABEL com.redhat.component="jenkins-slave-golang-rhel7-docker" \
       io.k8s.description="The jenkins slave golang image has the go runtime on top of the jenkins slave base image." \
       io.openshift.tags="openshift,jenkins,slave,golang"
 
-ENV GO_VERSION=1.10.2 \
+ENV GO_VERSION_DEFAULT=1.10.2 \
     GOROOT=/usr/local/go \
     GOPATH=/usr/src/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
@@ -20,8 +20,9 @@ RUN curl -L -o /tmp/sonar-scanner.zip https://binaries.sonarsource.com/Distribut
     mv sonar-scanner-* sonar-scanner && \
     ln -s /opt/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner && \
     chmod 755 /usr/local/bin/sonar-scanner
-ADD https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz /usr/
-RUN mkdir -p /usr/src/go/src/redhat && \
+RUN if [ -z $GO_VERSION ] ; then GO_VERSION=${GO_VERSION_DEFAULT} ; fi && \
+    curl -L -o /usr/go${GO_VERSION}.linux-amd64.tar.gz https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
+    mkdir -p /usr/src/go/src/redhat && \
     tar -xzf /usr/go${GO_VERSION}.linux-amd64.tar.gz && \
     mv $(pwd)/go /usr/local/ && \
     chown -R 1001 /usr/src/go && \


### PR DESCRIPTION
#### What is this PR About?
The PR adds the possibility to add the env GO_VERSION to the jenkins-slave-golang

#### How do we test this?
- Add the env "GO_VERSION=1.12.1" to the buildconfig

if you don't add the env GO_VERSION it will use the default 1.10.2


cc: @redhat-cop/day-in-the-life
