### PR TITLE
changed sonar Dockerfile to take plugin argument with defaults set

### DIFF
--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker.io/sonarqube:latest
 
 USER root
+ARG sonar_plugins="pmd gitlab github ldap"
 ADD sonar.properties /opt/sonarqube/conf/sonar.properties
 ADD run.sh /opt/sonarqube/bin/run.sh
 CMD /opt/sonarqube/bin/run.sh
@@ -8,7 +9,7 @@ RUN cp -a /opt/sonarqube/data /opt/sonarqube/data-init && \
 	cp -a /opt/sonarqube/extensions /opt/sonarqube/extensions-init && \
 	chown root:root /opt/sonarqube && chmod -R gu+rwX /opt/sonarqube
 ADD plugins.sh /opt/sonarqube/bin/plugins.sh
-RUN /opt/sonarqube/bin/plugins.sh pmd gitlab github ldap
+RUN /opt/sonarqube/bin/plugins.sh $sonar_plugins
 RUN chown root:root /opt/sonarqube -R; \
     chmod 6775 /opt/sonarqube -R
 USER 1001


### PR DESCRIPTION
#### What is this PR About?
This changes the sonarqube Dockerfile to take a list of arguments for plugins.

#### How do we test this?
Run the openshift-applier inventory against a cluster. Ensure that the ARG step is present in the build.

cc: @redhat-cop/day-in-the-life
