### PR TITLE
change default slave image tag to latest instead of v3.11, template s…

### DIFF
--- a/jenkins-slaves/.openshift/templates/jenkins-slave-generic-template.yml
+++ b/jenkins-slaves/.openshift/templates/jenkins-slave-generic-template.yml
@@ -75,7 +75,7 @@ parameters:
 - name: SLAVE_IMAGE_TAG
   displayName: Image tag for Jenkins slave.
   description: This is the image tag used for the Jenkins slave.
-  value: v3.11
+  value: latest 
 - name: DOCKERFILE_PATH
   displayName: Path to Dockerfile
   description: Path for alternate Dockerfile to use for build


### PR DESCRIPTION
…hould be generic as possible

#### What is this PR About?
Changing the default from v3.11 to latest for the `SLAVE_IMAGE_TAG`

#### How do we test this?
apply the applier

cc: @redhat-cop/day-in-the-life
