### PR TITLE
Remove deprecated github/gitlab plugins for SonarQube

### DIFF
--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/sonarqube:latest
 
 USER root
-ARG sonar_plugins="pmd gitlab github ldap"
+ARG sonar_plugins="pmd ldap"
 ADD sonar.properties /opt/sonarqube/conf/sonar.properties
 ADD run.sh /opt/sonarqube/bin/run.sh
 CMD /opt/sonarqube/bin/run.sh


### PR DESCRIPTION
#### What is this PR About?
Resolves #210 

The GitHub/GitLab plugins for SonarQube are deprecated and cause errors since version >= 7.3

#### How do we test this?

- cd sonarqube
- docker build -t sonartest .
- docker run sonartest
- Log in to running sonarqube container
- Navigate to Administration/MarketPlace/Installed
- Verify that the plugins are not  present

cc: @redhat-cop/day-in-the-life @oybed @sabre1041 @etsauer 
