### PR TITLE
Minor fix in arachni jenkins-slaves documentation

### DIFF
--- a/jenkins-slaves/jenkins-slave-arachni/README.md
+++ b/jenkins-slaves/jenkins-slave-arachni/README.md
@@ -6,12 +6,12 @@ Provides a docker image of the arachni security tool with an additional reporter
 
 ## Build in OpenShift
 ```bash
-oc process -f ../templates/jenkins-slave-generic-template.yml \
+oc process -f .openshift/templates/jenkins-slave-generic-template.yml \
     -p NAME=jenkins-slave-arachni \
     -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-arachni \
     | oc create -f -
 ```
-For all params see the list in the `../templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../templates/jenkins-slave-generic-template.yml`.
+For all params see the list in the `.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f .openshift/templates/jenkins-slave-generic-template.yml`.
 
 ## Run
 For local running and experimentation run `docker run -i -t --rm jenkins-slave-arachni /bin/bash` and have a play once inside the container. `/arachni` is where the product is and  `/arachni/bin/arachni` for the binary


### PR DESCRIPTION
#### What is this PR About?
Minor fix into the documentation for arachni jenkins-slaves documentation. 

#### How do we test this?
Tested in OCP4.1.4 environment.

```
[~/containers-quickstarts/jenkins-slaves/jenkins-slave-arachni master ⭑|…1]# oc process -f ../templates/jenkins-slave-generic-template.yml \
>     -p NAME=jenkins-slave-arachni \
>     -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-arachni \
>     | oc create -f -
error: failed to read input object (not a Template?): the path "../templates/jenkins-slave-generic-template.yml" does not exist
error: no objects passed to create
```

```
 [~/containers-quickstarts master ⭑|…1]# oc process -f .openshift/templates/jenkins-slave-generic-template.yml   -p NAME=jenkins-slave-arachni -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-arachni | oc create -f -
imagestream.image.openshift.io/jenkins-slave-arachni created
buildconfig.build.openshift.io/jenkins-slave-arachni created
```

cc: @redhat-cop/day-in-the-life
