### PR TITLE
fixes redhat-cop/containers-quickstarts#230

### DIFF
--- a/tool-box/Dockerfile
+++ b/tool-box/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 
-ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.11.0-0.32.0/linux/oc.tar.gz
+ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.11.127/linux/oc.tar.gz
 ENV HOME /home/tool-box
 
 RUN dnf -y update && \


### PR DESCRIPTION
#### What is this PR About?
Fixes #230 by updating the oc version to the latest 3.11 release

#### How do we test this?
readme steps should be the same for testing

cc: @redhat-cop/day-in-the-life
