### PR TITLE
Ensure tests fail if there are no builds found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ before_script:
   # Launch OpenShift Environment
   - _test/setup.sh cluster_up
   # Run Applier to provision all of the builds
-  - _test/setup.sh applier
+  - _test/setup.sh applier cqci-${TRAVIS_JOB_ID} ${TRAVIS_REPO_SLUG} ${TRAVIS_BRANCH}
 
 script:
   # Test to ensure that builds all succeed
-  - _test/setup.sh test
+  - _test/setup.sh test cqci-${TRAVIS_JOB_ID} ${TRAVIS_REPO_SLUG} ${TRAVIS_BRANCH}

--- a/TESTING.md
+++ b/TESTING.md
@@ -23,10 +23,24 @@ Every build that gets created will then be executed, and the test script will wa
 
 ## Running the tests locally.
 
-There are a number of ways to run the tests, but the easiest is to run all phases against a local cluster with `oc cluster up`:
+For convenience, a script is provided that allows users to run tests locally. The script usage is as follows:
 
 ```
-oc cluster up --base-dir=$HOME/ocp && \
+./_test/setup.sh <applier|test> [project name] [repo slug] [branch name]
+```
+
+For example, to test against master:
+
+```
+oc login ... && \
   ./_test/setup.sh applier && \
   ./_test/setup.sh test
+```
+
+To test against an alternate fork/branch:
+
+```
+oc login ... && \
+  ./_test/setup.sh applier etsauer-feature123 etsauer/containers-quickstarts feature123 && \
+  ./_test/setup.sh test etsauer-feature123 etsauer/containers-quickstarts feature123
 ```

--- a/_test/setup.sh
+++ b/_test/setup.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 trap "exit 1" TERM
 export TOP_PID=$$
-<<<<<<< Updated upstream
-NAMESPACE=containers-quickstarts-tests
-=======
 NAMESPACE="${2:-containers-quickstarts-tests}"
 TRAVIS_REPO_SLUG="${3:-redhat-cop/containers-quickstarts}"
 TRAVIS_BRANCH="${4:-master}"
->>>>>>> Stashed changes
 
 cluster_up() {
   set +e
@@ -30,10 +26,10 @@ cluster_up() {
 }
 
 applier() {
-  echo "${TRAVIS_BRANCH:=master}"
-  echo "${TRAVIS_REPO_SLUG:=redhat-cop/containers-quickstarts}"
+  echo "${TRAVIS_BRANCH}"
+  echo "${TRAVIS_REPO_SLUG}"
   ansible-galaxy install -r requirements.yml -p galaxy --force
-  ansible-playbook -i .applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e namespace=containers-quickstarts-tests -e slave_repo_ref=${TRAVIS_BRANCH} -e repository_url=https://github.com/${TRAVIS_REPO_SLUG}.git
+  ansible-playbook -i .applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e namespace=${NAMESPACE} -e slave_repo_ref=${TRAVIS_BRANCH} -e repository_url=https://github.com/${TRAVIS_REPO_SLUG}.git
 }
 
 get_build_phases() {
@@ -52,7 +48,7 @@ test() {
 
   echo "Ensure all Builds are executed..."
   for pipeline in $(oc get bc -n ${NAMESPACE} -o jsonpath='{.items[*].metadata.name}'); do
-    if [ "$(oc get build -n containers-quickstarts-tests -o jsonpath="{.items[?(@.metadata.annotations.openshift\.io/build-config\.name==\"${pipeline}\")].metadata.name}")" == "" ]; then
+    if [ "$(oc get build -n ${NAMESPACE} -o jsonpath="{.items[?(@.metadata.annotations.openshift\.io/build-config\.name==\"${pipeline}\")].metadata.name}")" == "" ]; then
       oc start-build ${pipeline} -n ${NAMESPACE}
     fi
   done

--- a/_test/setup.sh
+++ b/_test/setup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 trap "exit 1" TERM
 export TOP_PID=$$
+<<<<<<< Updated upstream
 NAMESPACE=containers-quickstarts-tests
+=======
+NAMESPACE="${2:-containers-quickstarts-tests}"
+TRAVIS_REPO_SLUG="${3:-redhat-cop/containers-quickstarts}"
+TRAVIS_BRANCH="${4:-master}"
+>>>>>>> Stashed changes
 
 cluster_up() {
   set +e
@@ -37,7 +43,12 @@ get_build_phases() {
 }
 
 test() {
-  #oc status || exit 1
+  # Make sure we're logged in, and we've found at least one build to test.
+  oc status > /dev/null || echo "Please log in before running tests." || exit 1
+  if [ $(oc get builds -n ${NAMESPACE} --no-headers | grep -c .) -lt 1 ]; then
+    echo "Did not find any builds, make sure you've passed the proper arguments."
+    exit 1
+  fi
 
   echo "Ensure all Builds are executed..."
   for pipeline in $(oc get bc -n ${NAMESPACE} -o jsonpath='{.items[*].metadata.name}'); do


### PR DESCRIPTION
#### What is this PR About?
We want to make sure we don't get false positives on tests where we're looking in the wrong namespace. To that, the test script now expects to find at least one build.

#### How do we test this?

```
oc login ...
./_test/setup.sh applier esauer-test-scripts etsauer/containers-quickstarts test-script-error && ./_test/setup.sh test esauer-test-scripts etsauer/containers-quickstarts test-script-error
```

cc: @redhat-cop/day-in-the-life
