### PR TITLE
WIP: Use ETL CI cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,12 @@ cache:
 
 env:
   global:
-    - ANSIBLE_HOST_KEY_CHECKING=False
-    - PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
-    - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.11.133/linux/oc.tar.gz
+    - ANSIBLE_HOST_KEY_CHECKING="False"
+    - PIP_DOWNLOAD_CACHE="$HOME/.cache/pip"
+    - OC_BINARY_URL="https://mirror.openshift.com/pub/openshift-v3/clients/3.11.133/linux/oc.tar.gz"
     - ANSIBLE_VERSION="2.7"
-    - CI_CLUSTER_URL=https://console.ci-1.cop.rht-labs.com
+    - OCP_CLUSTER_URL="https://console.ci-1.cop.rht-labs.com"
+    - LE_CA_CERT="https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem.txt"
 
 before_install:
   - sudo apt-get update -qq
@@ -24,10 +25,12 @@ install:
   #- pip install "ansible-lint<4.0" yamllint flake8 molecule docker "pytest<3.10" "testinfra==3.0.4"
   # Configure OpenShift Binary
   - sudo wget -qO- ${OC_BINARY_URL} | sudo tar -xvz -C /bin
+  # Download Lets Encrypt CA cert
+  - wget -qO le-ca-cert.pem ${LE_CA_CERT}
 
 before_script:
   # Login to the CI cluster
-  - oc login --token ${CI_CLUSTER_TOKEN} ${CI_CLUSTER_URL}
+  - oc login --token ${CI_CLUSTER_TOKEN} --server ${OCP_CLUSTER_URL} --certificate-authority le-ca-cert.pem
   # Run Applier to provision all of the builds
   - _test/setup.sh applier cqci-${TRAVIS_JOB_ID} ${TRAVIS_REPO_SLUG} ${TRAVIS_BRANCH}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ env:
   global:
     - ANSIBLE_HOST_KEY_CHECKING=False
     - PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
-    - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz
+    - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.11.133/linux/oc.tar.gz
     - ANSIBLE_VERSION="2.7"
+    - CI_CLUSTER_URL=https://console.ci-1.cop.rht-labs.com
 
 before_install:
   - sudo apt-get update -qq
@@ -25,16 +26,19 @@ install:
   - sudo wget -qO- ${OC_BINARY_URL} | sudo tar -xvz -C /bin
 
 before_script:
-  # Configure Docker
-  - sudo service docker stop
-  - sudo mkdir -p /etc/docker
-  - echo '{"insecure-registries":["172.30.0.0/16"]}' | sudo tee /etc/docker/daemon.json
-  - sudo service docker start
-  # Launch OpenShift Environment
-  - _test/setup.sh cluster_up
+  # Login to the CI cluster
+  - oc login --token ${CI_CLUSTER_TOKEN} ${CI_CLUSTER_URL}
   # Run Applier to provision all of the builds
   - _test/setup.sh applier cqci-${TRAVIS_JOB_ID} ${TRAVIS_REPO_SLUG} ${TRAVIS_BRANCH}
 
 script:
   # Test to ensure that builds all succeed
-  - _test/setup.sh test cqci-${TRAVIS_JOB_ID} ${TRAVIS_REPO_SLUG} ${TRAVIS_BRANCH}
+  - _test/setup.sh test cqci-${TRAVIS_JOB_ID}
+
+after_success:
+  # Delete CI project on successful completion
+  - _test/setup.sh cleanup cqci-${TRAVIS_JOB_ID}
+
+after_failure:
+  - echo "Job failed and will be deleted in 12 hours."
+  - echo "${TRAVIS_TEST_RESULT}"

--- a/_test/setup.sh
+++ b/_test/setup.sh
@@ -5,6 +5,10 @@ NAMESPACE="${2:-containers-quickstarts-tests}"
 TRAVIS_REPO_SLUG="${3:-redhat-cop/containers-quickstarts}"
 TRAVIS_BRANCH="${4:-master}"
 
+cleanup() {
+  oc delete project ${NAMESPACE}
+}
+
 cluster_up() {
   set +e
   built=false
@@ -77,6 +81,9 @@ test() {
 
 # Process arguments
 case $1 in
+  cleanup)
+    cleanup
+    ;;
   cluster_up)
     cluster_up
     ;;


### PR DESCRIPTION
#### What is this PR About?
Move CI run to ETL CI cluster since we're hitting resource limits with `cluster up` in Travis.
Also updating the oc client to 3.11.

#### How do we test this?
Should kick off automatically as part of our Travis CI integration.
Might be issues with the way we're trying to use the OCP token, see [Travis documentation](https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings)

cc: @redhat-cop/day-in-the-life
