### PR TITLE
Updated default context dir value as ansible-stacks no longer exists

### DIFF
--- a/.openshift/templates/jenkins-slave-ansible-stacks-template.yml
+++ b/.openshift/templates/jenkins-slave-ansible-stacks-template.yml
@@ -76,7 +76,7 @@ parameters:
 - description: Path within Git project to build; empty for root project directory.
   name: CONTEXT_DIR
   required: false
-  value: jenkins-slaves/jenkins-slave-ansible-stacks
+  value: jenkins-slaves/jenkins-slave-ansible
 - description: Git source URI for application
   name: ANSIBLE_STACKS_SOURCE_REPOSITORY_URL
   required: true


### PR DESCRIPTION
#### What is this PR About?
The default context dir value does not exist. Directory without *-stacks exists.

#### How do we test this?
Process yaml and apply

cc: @redhat-cop/day-in-the-life
