### PR TITLE
Add scl_enable to jenkins-slave-ansible to enable python 3.6

### DIFF
--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -26,6 +26,12 @@ jenkins_slaves:
 
 test_pipelines:
   deploy:
+    ansible:
+      NAME: jenkins-slave-ansible
+      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-ansible
+      PIPELINE_FILENAME: "Jenkinsfile.test"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     golang:
       NAME: jenkins-slave-golang
       PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-golang
@@ -61,6 +67,13 @@ openshift_cluster_content:
       - jenkins-slaves
 - object: test-pipelines
   content:
+  - name: Deploy ansible-slave test pipelines
+    template: "https://raw.githubusercontent.com/redhat-cop/openshift-templates/{{ templates_repo_ref }}/jenkins-pipelines/jenkins-pipeline-template-no-ocp-triggers.yml"
+    params_from_vars: "{{ test_pipelines.deploy.ansible }}"
+    namespace: "{{ namespace }}"
+    tags:
+      - test-pipelines
+      - ansible-slave-pipeline
   - name: Deploy golang-slave test pipelines
     template: "https://raw.githubusercontent.com/redhat-cop/openshift-templates/{{ templates_repo_ref }}/jenkins-pipelines/jenkins-pipeline-template-no-ocp-triggers.yml"
     params_from_vars: "{{ test_pipelines.deploy.golang }}"

--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -11,7 +11,7 @@ jenkins_slaves:
       DOCKERFILE_PATH: Dockerfile
       NAME: jenkins-slave-ansible
       SOURCE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-ansible
-      SOURCE_REPOSITORY_REF: v1.12
+      SOURCE_REPOSITORY_REF: master
       SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     arachni: {}
     python: {}

--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -11,7 +11,7 @@ jenkins_slaves:
       DOCKERFILE_PATH: Dockerfile
       NAME: jenkins-slave-ansible
       SOURCE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-ansible
-      SOURCE_REPOSITORY_REF: master
+      SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
       SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     arachni: {}
     python: {}

--- a/jenkins-slaves/jenkins-slave-ansible/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-ansible/Dockerfile
@@ -22,4 +22,9 @@ RUN INSTALL_PKGS="rh-python36-python-pip" && \
     yum $DISABLE_REPOS clean all -y && \
     rm -rf /var/cache/yum
 
+ADD scl_enable /usr/share/container-scripts/
+ENV BASH_ENV=/usr/share/container-scripts/scl_enable \
+    ENV=/usr/share/container-scripts/scl_enable \
+    PROMPT_COMMAND="./usr/share/container-scripts/scl_enable"
+
 USER 1001

--- a/jenkins-slaves/jenkins-slave-ansible/Jenkinsfile.test
+++ b/jenkins-slaves/jenkins-slave-ansible/Jenkinsfile.test
@@ -1,0 +1,15 @@
+pipeline {
+    agent {
+        label 'jenkins-slave-ansible'
+    }
+
+    stages {
+        stage ('Run Test') {
+            steps {
+                sh """
+                    ansible --version
+                """
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### What is this PR About?
Enable python 3.6 env in jenkins-slave-ansible to make ansible work in slave

#### How do we test this?
```
docker build -t jenkins-slave-ansible .
docker run -it --rm jenkins-slave-ansible /bin/bash
$ ansible --version
```

cc: @redhat-cop/day-in-the-life
