### PR TITLE
Fix sonarqube builds and use latest release

### DIFF
--- a/sonarqube/.applier/group_vars/seed-hosts.yml
+++ b/sonarqube/.applier/group_vars/seed-hosts.yml
@@ -1,11 +1,13 @@
 namespace: sonarqube
 app_name: sonarqube
 jenkins_url: http://jenkins:80
+upstream_sq_version: 7.9-community
+sonar_search_java_additional_opts: '-Dnode.store.allow_mmapfs=false'
 
 build:
   FROM_DOCKER_IMAGE: "{{ app_name }}"
   FROM_DOCKER_IMAGE_REGISTRY_URL: docker.io/sonarqube
-  FROM_DOCKER_TAG: 7.9-community
+  FROM_DOCKER_TAG: "{{ upstream_sq_version }}"
   NAME: "{{ app_name }}"
   SOURCE_REPOSITORY_URL: https://github.com/redhat-cop/containers-quickstarts.git
   SOURCE_REPOSITORY_REF: master
@@ -19,6 +21,7 @@ postgresql:
 deploy:
   POSTGRES_DATABASE_NAME: "{{ postgresql.POSTGRESQL_DATABASE }}"
   JENKINS_URL: "{{ jenkins_url }}"
+  SONAR_SEARCH_JAVA_ADDITIONAL_OPTS: "{{ sonar_search_java_additional_opts }}"
 
 openshift_cluster_content:
 - object: Environment Setup

--- a/sonarqube/.applier/group_vars/seed-hosts.yml
+++ b/sonarqube/.applier/group_vars/seed-hosts.yml
@@ -3,6 +3,9 @@ app_name: sonarqube
 jenkins_url: http://jenkins:80
 
 build:
+  FROM_DOCKER_IMAGE: "{{ app_name }}"
+  FROM_DOCKER_IMAGE_REGISTRY_URL: docker.io/sonarqube
+  FROM_DOCKER_TAG: 7.9-community
   NAME: "{{ app_name }}"
   SOURCE_REPOSITORY_URL: https://github.com/redhat-cop/containers-quickstarts.git
   SOURCE_REPOSITORY_REF: master
@@ -31,7 +34,7 @@ openshift_cluster_content:
 - object: Builds
   content:
   - name: sonarqube
-    template: "{{ inventory_dir }}/../../build-docker-generic/.openshift/templates/docker-build-template.yml"
+    template: "{{ inventory_dir }}/../../build-docker-generic/.openshift/templates/docker-build-template-override-FROM.yml"
     params_from_vars: "{{ build }}"
     namespace: "{{ namespace }}"
     tags:

--- a/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
+++ b/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
@@ -275,3 +275,6 @@ parameters:
     description: The Jenkins URL used for the webhook
     displayName: Jenkins URL
     value: http://jenkins
+  - name: SONAR_SEARCH_JAVA_ADDITIONAL_OPTS
+    description: Pass in additional Java opts to ElasticSearch
+    displayName: Add sonar.search.javaAdditionalOpts

--- a/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
+++ b/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
@@ -114,6 +114,8 @@ objects:
               secretKeyRef:
                 key: password
                 name: sonar-ldap-bind-dn
+          - name: SONAR_SEARCH_JAVA_ADDITIONAL_OPTS
+            value: '-Dnode.store.allow_mmapfs=false'
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/sonarqube/README.md
+++ b/sonarqube/README.md
@@ -8,6 +8,8 @@ but it has been modified to allow permissions to be run in an OpenShift environm
 * supports for persistent volumes for configuration, plugins & elastic indices
 * additional configuration options
 
+>**NOTE:** By default this image will disable memory mapping in Elasticsearch. See upstream issues [#310](https://github.com/SonarSource/docker-sonarqube/issues/310) & [SONAR-12264](https://jira.sonarsource.com/browse/SONAR-12264). This is not suitable for production use. This can be changed by using an older version of sonarqube, add `-e upstream_sq_version=7.7-community -e sonar_search_java_additional_opts=''` to the `ansible-playbook` command below
+
 ## Usage
 
 1. Clone this repository: `git clone https://github.com/redhat-cop/containers-quickstarts`
@@ -162,6 +164,10 @@ variable like `SONARQUBE_WEB_JVM_OPTS="-Dsonar.auth.google.allowUsersToSignUp=fa
   * displayName: Require Authentication
   * Description: Require authentication for all requests to sonarqube
   * Default Value: "true"
+* Variable: SONAR_SEARCH_JAVA_ADDITIONAL_OPTS
+  * displayName: Add sonar.search.javaAdditionalOpts
+  * Description: Pass in additional Java opts to ElasticSearch
+  * Default Value:
 
 ## Example LDAP Configurations
 

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -5,6 +5,7 @@ sonar.jdbc.url=${env:JDBC_URL}
 sonar.forceAuthentication=${env:FORCE_AUTHENTICATION}
 sonar.authenticator.createUsers=${env:SONAR_AUTOCREATE_USERS}
 sonar.log.level=${env:SONAR_LOG_LEVEL}
+sonar.search.javaAdditionalOpts=${env:SONAR_SEARCH_JAVA_ADDITIONAL_OPTS}
 http.proxyHost=${env:PROXY_HOST}
 http.proxyPort=${env:PROXY_PORT}
 http.proxyUser=${env:PROXY_USER}


### PR DESCRIPTION
#### What is this PR About?
The latest upstream release of Sonarqube will not run on Openshift. This PR will let you disable memory mapping for Elasticsearch and let Sonarqube start.
It will also let you specify the upstream version of Sonarqube and thus you can revert to `7.7-community` release if you don't want to disable memory mapping in Elasticsearch.

#### How do we test this?
Follow instructions in README

cc: @redhat-cop/day-in-the-life
