### PR TITLE
Creating UBI8 base tool-box image

### DIFF
--- a/tool-box/Dockerfile
+++ b/tool-box/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8
+FROM registry.access.redhat.io/ubi8
 
 MAINTAINER Aly Ibrahim<aly@redhat.com>
 

--- a/tool-box/Dockerfile
+++ b/tool-box/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.io/ubi8
+FROM registry.access.redhat.com/ubi8
 
 MAINTAINER Aly Ibrahim<aly@redhat.com>
 

--- a/tool-box/Dockerfile
+++ b/tool-box/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -m 775 $HOME && \
 
 RUN curl -s https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz | tar -xvz && \
     chmod u+x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/ && rm -rf linux-amd64 && \
-     helm init --client-only
+    helm init --client-only
 
 RUN curl -sL https://github.com/tektoncd/cli/releases/download/v0.3.1/tkn_0.3.1_Linux_x86_64.tar.gz | tar --no-same-owner -xvz -C /usr/local/bin/ tkn
 

--- a/tool-box/Dockerfile
+++ b/tool-box/Dockerfile
@@ -18,13 +18,13 @@ RUN mkdir -m 775 $HOME && \
     chmod 775 /etc/passwd && \ 
     pip3 install git+https://github.com/ansible/ansible.git@stable-2.8
 
-RUN  curl -s https://storage.googleapis.com/kubernetes-helm/helm-v2.9.0-linux-amd64.tar.gz | tar -xvz && \
-     chmod u+x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/ && rm -rf linux-amd64 && \
+RUN curl -s https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz | tar -xvz && \
+    chmod u+x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/ && rm -rf linux-amd64 && \
      helm init --client-only
 
 RUN curl -sL https://github.com/tektoncd/cli/releases/download/v0.3.1/tkn_0.3.1_Linux_x86_64.tar.gz | tar --no-same-owner -xvz -C /usr/local/bin/ tkn
 
-RUN  curl $OC_CLIENT_MIRROR | tar -C /usr/local/bin/ -xzf -
+RUN curl $OC_CLIENT_MIRROR | tar -C /usr/local/bin/ -xzf -
 
 RUN curl -sL https://github.com/openshift/odo/releases/latest/download/odo-linux-amd64 -o /usr/local/bin/odo && chmod +x /usr/local/bin/odo
 

--- a/tool-box/Dockerfile
+++ b/tool-box/Dockerfile
@@ -1,16 +1,32 @@
-FROM fedora:latest
+FROM registry.redhat.io/ubi8
+
+MAINTAINER Aly Ibrahim<aly@redhat.com>
 
 ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.11.127/linux/oc.tar.gz
 ENV HOME /home/tool-box
 
-RUN dnf -y update && \
-    INSTALL_PKGS="git tree vim unzip python-pip jq" && \
-    dnf -y install $INSTALL_PKGS && \
-    dnf clean all && \
-    curl $OC_CLIENT_MIRROR | tar -C /usr/local/bin/ -xzf - && \
-    mkdir -m 775 $HOME && \
-    chmod 775 /etc/passwd && \
-    pip install git+https://github.com/ansible/ansible.git@stable-2.6
+RUN yum -y update && \
+    INSTALL_PKGS="git vim unzip python36" && \
+    yum -y install $INSTALL_PKGS && \
+    yum clean all
+
+RUN curl -o jq -sL https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+    chmod +x jq && \
+    mv jq /usr/local/bin
+
+RUN mkdir -m 775 $HOME && \
+    chmod 775 /etc/passwd && \ 
+    pip3 install git+https://github.com/ansible/ansible.git@stable-2.8
+
+RUN  curl -s https://storage.googleapis.com/kubernetes-helm/helm-v2.9.0-linux-amd64.tar.gz | tar -xvz && \
+     chmod u+x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/ && rm -rf linux-amd64 && \
+     helm init --client-only
+
+RUN curl -sL https://github.com/tektoncd/cli/releases/download/v0.3.1/tkn_0.3.1_Linux_x86_64.tar.gz | tar --no-same-owner -xvz -C /usr/local/bin/ tkn
+
+RUN  curl $OC_CLIENT_MIRROR | tar -C /usr/local/bin/ -xzf -
+
+RUN curl -sL https://github.com/openshift/odo/releases/latest/download/odo-linux-amd64 -o /usr/local/bin/odo && chmod +x /usr/local/bin/odo
 
 WORKDIR $HOME
 
@@ -22,3 +38,4 @@ USER 1001
 
 ENTRYPOINT ["/usr/local/bin/run"]
 CMD ["sleep", "infinity"]
+

--- a/tool-box/README.md
+++ b/tool-box/README.md
@@ -7,11 +7,14 @@ This container exists to help folks that can't install ansible, git or other nec
 ## What's in the box?
 
 - `oc` version 3.11.0-0.32.0
-- `ansible` 2.6 (stable from `pip`)
+- `ansible` v2.8 (stable from `pip`)
+- `python` v3.6
 - `git`
-- `tree`
 - `unzip`
-- `jq`
+- `jq` v1.6
+- `odo`
+- `helm` Client v2.9.0
+- `tkn` Client v0.3.1
 
 If you need something not here, let us know in an issue or submit a PR.
 

--- a/tool-box/README.md
+++ b/tool-box/README.md
@@ -13,7 +13,7 @@ This container exists to help folks that can't install ansible, git or other nec
 - `unzip`
 - `jq` v1.6
 - `odo`
-- `helm` Client v2.9.0
+- `helm` Client v2.14.3
 - `tkn` Client v0.3.1
 
 If you need something not here, let us know in an issue or submit a PR.


### PR DESCRIPTION
#### What is this PR About?
The current tool-box is using Fedore-30, and Ansible 2.6.
I created a new tool-box using UBI8 base image in addition to the following :
- Updated Ansible version to 2.8
- Add helm client
- Add tekton client
- Add odo CLI tool
- Remove Tree

#### How do we test this?
Docker build using the provided Dockerfile can generate the image with the new tools

cc: @redhat-cop/day-in-the-life
