### PR TITLE
sonarqube: use openshift oauth for login

### DIFF
--- a/sonarqube/.applier/group_vars/seed-hosts.yml
+++ b/sonarqube/.applier/group_vars/seed-hosts.yml
@@ -1,7 +1,7 @@
 namespace: sonarqube
 app_name: sonarqube
 jenkins_url: http://jenkins:80
-upstream_sq_version: 7.9-community
+upstream_sq_version: 7.9.1-community
 sonar_search_java_additional_opts: '-Dnode.store.allow_mmapfs=false'
 
 build:

--- a/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
+++ b/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
@@ -151,6 +151,8 @@ objects:
         restartPolicy: Always
         schedulerName: default-scheduler
         securityContext: {}
+        serviceAccount: sonarqube
+        serviceAccountName: sonarqube
         terminationGracePeriodSeconds: 30
         volumes:
         - name: sonar-data
@@ -199,6 +201,21 @@ objects:
       deploymentconfig: sonarqube
     sessionAffinity: None
     type: ClusterIP
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.sonarqube: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"sonarqube"}}'
+    name: sonarqube
+- apiVersion: v1
+  kind: RoleBinding
+  metadata:
+    name: sonarqube_view
+  roleRef:
+    name: view
+  subjects:
+  - kind: ServiceAccount
+    name: sonarqube
 parameters:
   - description: Database name for the Posgres Database to be used by Sonarqube
     displayName: Postgres database name

--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -9,6 +9,7 @@ RUN cp -a /opt/sonarqube/data /opt/sonarqube/data-init && \
 	cp -a /opt/sonarqube/extensions /opt/sonarqube/extensions-init && \
 	chown root:root /opt/sonarqube && chmod -R gu+rwX /opt/sonarqube
 ADD plugins.sh /opt/sonarqube/bin/plugins.sh
+ADD https://github.com/rht-labs/sonar-auth-openshift/releases/latest/download/sonar-auth-openshift-plugin.jar /opt/sonarqube/extensions-init/plugins/
 RUN /opt/sonarqube/bin/plugins.sh $sonar_plugins
 RUN chown root:root /opt/sonarqube -R; \
     chmod 6775 /opt/sonarqube -R

--- a/sonarqube/README.md
+++ b/sonarqube/README.md
@@ -7,6 +7,7 @@ but it has been modified to allow permissions to be run in an OpenShift environm
 * ability to define plugins to be installed the first time the container is run. 
 * supports for persistent volumes for configuration, plugins & elastic indices
 * additional configuration options
+* ability to login using the OpenShift provided OAuth server (enabled by default) - see [plugin docs](https://github.com/rht-labs/sonar-auth-openshift) for configuration and disable information
 
 >**NOTE:** By default this image will disable memory mapping in Elasticsearch. See upstream issues [#310](https://github.com/SonarSource/docker-sonarqube/issues/310) & [SONAR-12264](https://jira.sonarsource.com/browse/SONAR-12264). This is not suitable for production use. This can be changed by using an older version of sonarqube, add `-e upstream_sq_version=7.7-community -e sonar_search_java_additional_opts=''` to the `ansible-playbook` command below
 

--- a/sonarqube/README.md
+++ b/sonarqube/README.md
@@ -18,6 +18,12 @@ but it has been modified to allow permissions to be run in an OpenShift environm
 3. Run `ansible-galaxy install -r requirements.yml --roles-path=galaxy`
 4. Login to OpenShift: `oc login -u <username> https://master.example.com:8443`
 
+### Settings
+
+There are a couple of settings that may need to be configured in order for this to work properly. By default authorization is determined by the users membership in the groups `sonar-administrators` for admins and `sonar-users` for ordinary users. To change the group association review the configuration instructions [here](https://github.com/rht-labs/sonar-auth-openshift/). To create a custom group see the example [here](https://github.com/rht-labs/sonar-auth-openshift/blob/master/example/files/sonarqube-admin-group.yml).
+
+In many cases the certs that are associated with the pod are the same as those associated with the OpenShift oauth server. If true, then no configuration is necessary. If the cert is not the same than you will need to provide the correct cert. Your 2 options are to ignore the cert `ignore.certs=true` (only do this for testing puropses) or provide the correct cert. See [here](https://github.com/rht-labs/sonar-auth-openshift/) for instructions. 
+
 ### Build and Deploy SonarQube
 
 Run the openshift-applier to create the `SonarQube` project and deploy required objects

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -24,3 +24,5 @@ ldap.user.emailAttribute=${env:LDAP_USER_EMAIL_ATTR}
 ldap.group.baseDn=${env:LDAP_GROUP_BASEDN}
 ldap.group.request=${env:LDAP_GROUP_REQUEST}
 ldap.group.idAttribute=${env:LDAP_GROUP_ID_ATTR}
+kubernetes.service=https://${env:KUBERNETES_SERVICE_HOST}:${env:KUBERNETES_SERVICE_PORT}/
+sonar.auth.openshift.isEnabled=true


### PR DESCRIPTION
#### What is this PR About?
Resolves #257 - Enables authentication by OpenShift by default (turn off in properties file)
Removes windows line breaks from the sonar.properties file (all lines appear modified but only the last 2 are new. All else should be the same)
updates from 7.9 to 7.9.1


#### How do we test this?
1. get MR code on your machine 
2. following instructions in README https://github.com/redhat-cop/containers-quickstarts/tree/master/sonarqube

3. then, since this repo will point the build to the master branch, run a new build  

```
oc start-build sonarqube --from-dir=.. -n sonarqube
```

4. Go to sonar home page. There should now be a 'login with OpenShift link'
5. You should be redirected to the OpenShift login screen. --> Login.
6. You should be redirected to Sonarqube and see the projects page (empty)


cc: @redhat-cop/day-in-the-life
