### PR TITLE
Fix path to jenkins-slave-generic-template in Jenkins slave READMEs

### DIFF
--- a/jenkins-slaves/jenkins-slave-ansible/README.md
+++ b/jenkins-slaves/jenkins-slave-ansible/README.md
@@ -5,19 +5,19 @@ This is a Jenkins Slave designed to run in OpenShift as described [here](https:/
 Provides a docker image with ansible for use as a Jenkins slave.
 
 ## Build local
-`docker build -t jenkins-slave-ansible.`
+`docker build -t jenkins-slave-ansible .`
 
 ## Run local
 For local running and experimentation run `docker run -i -t jenkins-slave-ansible /bin/bash` and have a play once inside the container.
 
 ## Build in OpenShift
 ```bash
-oc process -f ../templates/jenkins-slave-generic-template.yml \
+oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
     -p NAME=jenkins-slave-ansible \
     -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-ansible \
     | oc create -f -
 ```
-For all params see the list in the `../templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../templates/jenkins-slave-generic-template.yml`.
+For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.
 
 ## Jenkins
 Add a new Kubernetes Container template called `jenkins-slave-ansible` (if you've build and pushed the container image locally) and specify this as the node when running builds. If you're using the template attached; the `role: jenkins-slave` is attached and Jenkins should automatically discover the slave for you. Further instructions can be found [here](https://docs.openshift.com/container-platform/3.10/using_images/other_images/jenkins.html#using-the-jenkins-kubernetes-plug-in). 

--- a/jenkins-slaves/jenkins-slave-arachni/README.md
+++ b/jenkins-slaves/jenkins-slave-arachni/README.md
@@ -6,12 +6,12 @@ Provides a docker image of the arachni security tool with an additional reporter
 
 ## Build in OpenShift
 ```bash
-oc process -f .openshift/templates/jenkins-slave-generic-template.yml \
+oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
     -p NAME=jenkins-slave-arachni \
     -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-arachni \
     | oc create -f -
 ```
-For all params see the list in the `.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f .openshift/templates/jenkins-slave-generic-template.yml`.
+For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.
 
 ## Run
 For local running and experimentation run `docker run -i -t --rm jenkins-slave-arachni /bin/bash` and have a play once inside the container. `/arachni` is where the product is and  `/arachni/bin/arachni` for the binary

--- a/jenkins-slaves/jenkins-slave-golang/README.md
+++ b/jenkins-slaves/jenkins-slave-golang/README.md
@@ -9,12 +9,12 @@ For local running and experimentation run `docker run -i -t jenkins-slave-golang
 
 ## Build in OpenShift
 ```bash
-oc process -f ../templates/jenkins-slave-generic-template.yml \
+oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
     -p NAME=jenkins-slave-golang \
     -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-golang \
     | oc create -f -
 ```
-For all params see the list in the `../templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../templates/jenkins-slave-generic-template.yml`.
+For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.
 
 ## Jenkins
 Add a new Kubernetes Container template called `jenkins-slave-golang` (if you've build and pushed the container image locally) and specify this as the node when running builds. If you're using the template attached; the `role: jenkins-slave` is attached and Jenkins should automatically discover the slave for you. Further instructions can be found [here](https://docs.openshift.com/container-platform/3.7/using_images/other_images/jenkins.html#using-the-jenkins-kubernetes-plug-in-to-run-jobs). There are path issues with Jenkins permissions and Go when trying to run a build so easiest way to fix this is to setup the GOLANG path to be same as the WORKSPACE

--- a/jenkins-slaves/jenkins-slave-gradle/README.md
+++ b/jenkins-slaves/jenkins-slave-gradle/README.md
@@ -6,12 +6,12 @@ Provides a docker image of the gradle runtime for use as a Jenkins slave.
 
 ## Build in OpenShift
 ```bash
-oc process -f ../templates/jenkins-slave-generic-template.yml \
+oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
     -p NAME=jenkins-slave-gradle \
     -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-gradle \
     | oc create -f -
 ```
-For all params see the list in the `../templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../templates/jenkins-slave-generic-template.yml`.
+For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.
 
 ## Run
 For local running and experimentation run `docker run -i -t --rm jenkins-slave-gradle /bin/bash` and have a play once inside the container.

--- a/jenkins-slaves/jenkins-slave-image-mgmt/README.md
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/README.md
@@ -10,12 +10,12 @@ Jenkins [Slave](https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds) 
 
 ## Instantiate Template
 
-A [template]../../.openshift/templates/jenkins-slave-image-mgmt-template.yml) is available providing the necessary OpenShift components to build and make the slave image available to be referenced by Jenkins.
+A [template](../../.openshift/templates/jenkins-slave-image-mgmt-template.yml) is available providing the necessary OpenShift components to build and make the slave image available to be referenced by Jenkins.
 
 Execute the following command to instantiate the template:
 
 ```
-oc process -f ../templates/jenkins-slave-image-mgmt-template.yml | oc apply -f-
+oc process -f ../../.openshift/templates/jenkins-slave-image-mgmt-template.yml | oc apply -f-
 ```
 
 A new image build will be started automatically

--- a/jenkins-slaves/jenkins-slave-mongodb/README.md
+++ b/jenkins-slaves/jenkins-slave-mongodb/README.md
@@ -9,12 +9,12 @@ For local running and experimentation run `docker run -i -t  jenkins-slave-mongo
 
 ## Build in OpenShift
 ```bash
-oc process -f ../templates/jenkins-slave-generic-template.yml \
+oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
     -p NAME=jenkins-slave-mongodb \
     -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-mongodb \
     | oc create -f -
 ```
-For all params see the list in the `../templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../templates/jenkins-slave-generic-template.yml`.
+For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.
 
 ## Jenkins Running
 Add a new Kubernetes Container template called `jenkins-slave-mongodb` and specify this as the node when running builds. Eg below for adding a new collection to a mongodb in OCP. NOTE: you may have to [connect the networks](https://docs.openshift.com/container-platform/3.11/admin_guide/managing_networking.html#joining-project-networks) if deploying to a namespace outside where the Slave container is running.

--- a/jenkins-slaves/jenkins-slave-mvn/README.md
+++ b/jenkins-slaves/jenkins-slave-mvn/README.md
@@ -4,10 +4,10 @@ This slave extends [the Jenkins Maven Slave shipped with OpenShift](https://acce
 
 ## Build in OpenShift
 ```bash
-oc process -f ../templates/jenkins-slave-generic-template.yml \
+oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
     -p NAME=jenkins-slave-mvn \
     -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-mvn \
     -p DOCKERFILE_PATH=Dockerfile \
     | oc create -f -
 ```
-For all params see the list in the `../templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../templates/jenkins-slave-generic-template.yml`.
+For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.

--- a/jenkins-slaves/jenkins-slave-npm/README.md
+++ b/jenkins-slaves/jenkins-slave-npm/README.md
@@ -15,17 +15,17 @@ For local running and experimentation run `docker run -i -t jenkins-slave-npm /b
 
 ## Build in OpenShift
 ```bash
-oc process -f ../.openshift/templates/jenkins-slave-generic-template.yml \
+oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
     -p NAME=jenkins-slave-npm \
     -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-npm \
     | oc apply -f -
 ```
-For all params see the list in the `../templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../templates/jenkins-slave-generic-template.yml`.
+For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.
 
 ## Jenkins
 Add a new Kubernetes Container template called `jenkins-slave-npm` (if you've build and pushed the container image locally) and specify this as the node when running builds. If you're using the template attached; the `role: jenkins-slave` is attached and Jenkins should automatically discover the slave for you. Further instructions can be found [here](https://docs.openshift.com/container-platform/3.7/using_images/other_images/jenkins.html#using-the-jenkins-kubernetes-plug-in-to-run-jobs).
 
-Add this new Kubernetes Container template and specify this as the node when running builds. 
+Add this new Kubernetes Container template and specify this as the node when running builds.
 ```
 npm install
 npm run build

--- a/jenkins-slaves/jenkins-slave-python/README.md
+++ b/jenkins-slaves/jenkins-slave-python/README.md
@@ -9,13 +9,13 @@ For local running and experimentation run `docker run -i -t jenkins-slave-python
 
 ## Build in OpenShift
 ```bash
-oc process -f ../templates/jenkins-slave-generic-template.yml \
+oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
     -p NAME=jenkins-slave-python \
     -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-python \
     -p DOCKERFILE_PATH=Dockerfile \
     | oc create -f -
 ```
-For all params see the list in the `../templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../templates/jenkins-slave-generic-template.yml`.
+For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.
 
 ## Jenkins
 Add a new Kubernetes Container template called `jenkins-slave-python` (if you've build and pushed the container image locally) and specify this as the node when running builds. If you're using the template attached; the `role: jenkins-slave` is attached and Jenkins should automatically discover the slave for you. Further instructions can be found [here](https://docs.openshift.com/container-platform/3.7/using_images/other_images/jenkins.html#using-the-jenkins-kubernetes-plug-in-to-run-jobs). Python installation commands are slightly modified from the SCL versions, which can be found [here](https://github.com/sclorg/s2i-python-container/tree/master/3.6).

--- a/jenkins-slaves/jenkins-slave-ruby/README.md
+++ b/jenkins-slaves/jenkins-slave-ruby/README.md
@@ -16,10 +16,13 @@ A [template](../../.openshift/templates/jenkins-slave-generic-template.yml) is a
 Execute the following command to instantiate the template:
 
 ```
-oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml | oc apply -f-
+oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
+    -p NAME=jenkins-slave-ruby \
+    -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-ruby \
+    | oc create -f -
 ```
 
-A new image build will be started automatically
+A new image build will be started automatically. For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.
 
 ## Use within Jenkins
 

--- a/jenkins-slaves/jenkins-slave-zap/README.md
+++ b/jenkins-slaves/jenkins-slave-zap/README.md
@@ -13,7 +13,7 @@ For local running and experimentation run `docker run -i -t jenkins-slave-zap /b
 ## Build in OpenShift
 
 ```bash
-oc process -f ../templates/jenkins-slave-generic-template.yml \
+oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
     -p NAME=jenkins-slave-zap \
     -p SOURCE_CONTEXT_DIR=jenkins-slaves/jenkins-slave-zap \
     -p BUILDER_IMAGE_NAME=centos:centos7 \
@@ -21,7 +21,7 @@ oc process -f ../templates/jenkins-slave-generic-template.yml \
     | oc create -f -
 ```
 
-For all params see the list in the `../templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../templates/jenkins-slave-generic-template.yml`.
+For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.
 
 ## Jenkins
 


### PR DESCRIPTION
#### What is this PR About?
- Updated the path to jenkins-slave-generic-template.yml in the Jenkins slave READMEs to point to the correct location. 
- Also, corrected the example in the README for the Ruby slave.

#### How do we test this?
Run the example commands given in each README file.

Resolves #228 

cc: @redhat-cop/day-in-the-life
