### PR TITLE
Fix jenkins-slave-mvn to actually have mvn

### DIFF
--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -19,6 +19,7 @@ jenkins_slaves:
     gradle: {}
     mongodb: {}
     mvn: {}
+      BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-maven:4.1
     npm:
       BUILDER_IMAGE_NAME: openshift/jenkins-slave-base-centos7:v3.11
     ruby: {}

--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -39,6 +39,12 @@ test_pipelines:
       PIPELINE_FILENAME: Jenkinsfile.test
       PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
+    mvn:
+      NAME: jenkins-slave-mvn
+      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-mvn
+      PIPELINE_FILENAME: Jenkinsfile.test
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     ruby:
       NAME: jenkins-slave-ruby
       PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-ruby
@@ -89,6 +95,13 @@ openshift_cluster_content:
     tags:
       - test-pipelines
       - golang-slave-pipeline
+  - name: Deploy mvn-slave test pipelines
+    template: "https://raw.githubusercontent.com/redhat-cop/openshift-templates/{{ templates_repo_ref }}/jenkins-pipelines/jenkins-pipeline-template-no-ocp-triggers.yml"
+    params_from_vars: "{{ test_pipelines.deploy.mvn }}"
+    namespace: "{{ namespace }}"
+    tags:
+      - test-pipelines
+      - mvn-slave-pipeline
   - name: Deploy ruby-slave test pipelines
     template: "https://raw.githubusercontent.com/redhat-cop/openshift-templates/{{ templates_repo_ref }}/jenkins-pipelines/jenkins-pipeline-template-no-ocp-triggers.yml"
     params_from_vars: "{{ test_pipelines.deploy.ruby }}"

--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -18,7 +18,7 @@ jenkins_slaves:
     golang: {}
     gradle: {}
     mongodb: {}
-    mvn: {}
+    mvn:
       BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-maven:4.1
     npm:
       BUILDER_IMAGE_NAME: openshift/jenkins-slave-base-centos7:v3.11

--- a/jenkins-slaves/jenkins-slave-mvn/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-mvn/Dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.1
+FROM quay.io/openshift/origin-jenkins-agent-maven:4.1
 ADD settings.xml $HOME/.m2/settings.xml

--- a/jenkins-slaves/jenkins-slave-mvn/Jenkinsfile.test
+++ b/jenkins-slaves/jenkins-slave-mvn/Jenkinsfile.test
@@ -1,0 +1,17 @@
+pipeline {
+    agent {
+      label 'jenkins-slave-mvn'
+    }
+
+    stages {
+        stage ('Run Test') {
+            steps {
+              sh """
+                  mvn --version
+              """
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
#### What is this PR About?
The current `jenkins-slave-mvn` image does not have maven installed. This PR will fix this and also add a test for `mvn`.

#### How do we test this?
Follow instructions in `TESTING.md`

cc: @redhat-cop/day-in-the-life
