### PR TITLE
Updated jenkins slaves to 4.2 bases

### DIFF
--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -7,7 +7,7 @@ templates_repo_ref: v1.4.12
 jenkins_slaves:
   build:
     ansible:
-      BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-base:4.1
+      BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-base:4.2
       DOCKERFILE_PATH: Dockerfile
       NAME: jenkins-slave-ansible
       SOURCE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-ansible
@@ -19,7 +19,7 @@ jenkins_slaves:
     gradle: {}
     mongodb: {}
     mvn:
-      BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-maven:4.1
+      BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-maven:4.2
     npm:
       BUILDER_IMAGE_NAME: openshift/jenkins-slave-base-centos7:v3.11
     ruby: {}

--- a/.openshift/templates/jenkins-slave-generic-template.j2
+++ b/.openshift/templates/jenkins-slave-generic-template.j2
@@ -44,7 +44,7 @@ objects:
         dockerfilePath: {{ params.DOCKERFILE_PATH | d('Dockerfile') }}
         from:
           kind: DockerImage
-          name: {{ params.BUILDER_IMAGE_NAME | d('quay.io/openshift/origin-jenkins-agent-base:4.1') }}
+          name: {{ params.BUILDER_IMAGE_NAME | d('quay.io/openshift/origin-jenkins-agent-base:4.2') }}
           imagePullPolicy: Always
       type: Docker
     triggers:

--- a/jenkins-slaves/jenkins-slave-ansible/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-ansible/Dockerfile
@@ -1,8 +1,8 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.1
+FROM quay.io/openshift/origin-jenkins-agent-base:4.2
 
 LABEL com.redhat.component="jenkins-agent-ansible-ubi7-docker" \
       name="openshift/origin-jenkins-agent-ansible-ubi7" \
-      version="4.1" \
+      version="4.2" \
       architecture="x86_64" \
       release="1" \
       io.k8s.display-name="Jenkins Agent Ansible" \

--- a/jenkins-slaves/jenkins-slave-arachni/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-arachni/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.1
+FROM quay.io/openshift/origin-jenkins-agent-base:4.2
 
 ARG VERSION=1.5.1
 ARG WEB_VERSION=0.5.12

--- a/jenkins-slaves/jenkins-slave-golang/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.1
+FROM quay.io/openshift/origin-jenkins-agent-base:4.2
 
 ENV GO_VERSION_DEFAULT=1.10.2 \
     GOROOT=/usr/local/go \

--- a/jenkins-slaves/jenkins-slave-gradle/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-gradle/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.1
+FROM quay.io/openshift/origin-jenkins-agent-base:4.2
 
 ENV GRADLE_VERSION=4.8
 

--- a/jenkins-slaves/jenkins-slave-mongodb/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-mongodb/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.1
+FROM quay.io/openshift/origin-jenkins-agent-base:4.2
 
 USER root
 

--- a/jenkins-slaves/jenkins-slave-mvn/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-mvn/Dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/openshift/origin-jenkins-agent-maven:4.1
+FROM quay.io/openshift/origin-jenkins-agent-maven:4.2
 ADD settings.xml $HOME/.m2/settings.xml

--- a/jenkins-slaves/jenkins-slave-python/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.1
+FROM quay.io/openshift/origin-jenkins-agent-base:4.2
 
 EXPOSE 8080
 

--- a/jenkins-slaves/jenkins-slave-ruby/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.1
+FROM quay.io/openshift/origin-jenkins-agent-base:4.2
 
 ENV RUBY_VERSION=2.5 \
   RUBY_SHORT_VERSION=25


### PR DESCRIPTION
#### What is this PR About?
Updated the jenkins slaves to use 4.2 as their base.

#### How do we test this?
- Check prow logs, builds should pass.
- Build slaves manually via applier instructions in each directory

cc: @redhat-cop/day-in-the-life
