### PR TITLE
created a basic eap 7.2 Helm chart

### DIFF
--- a/helm-charts/eap72/Chart.yaml
+++ b/helm-charts/eap72/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: 7.2
+description: Deploy an EAP application onto OpenShift
+name: eap72
+version: 0.0.1

--- a/helm-charts/eap72/README.md
+++ b/helm-charts/eap72/README.md
@@ -1,0 +1,60 @@
+# EAP 7.2 Helm Chart
+A Helm chart for deploying an EAP application to OpenShift.
+
+## Installation
+Users must provide a "sourceUri" value, which should point to a git repository containing a Java application. Run the installation with the following command.
+```bash
+helm install my-eap-application . --set sourceUri=repository-uri
+```
+
+## Rolling out the Application
+Users must first start a new build by running  the following command.
+```bash
+oc start-build $RELEASE_NAME
+```
+
+The appliction will be automatically rolled out when the build finishes.
+
+## Enabling TLS
+TLS can be enabled with the "enableTls" value. Communication within the cluster will be encrypted when this value is set to "true". Traffic from outside of the cluster is encrypted regardless of this value's setting.
+
+Users must provide a secret containing a JGroups keystore and a secret containing an keystore for client traffic. 
+
+Create a JGroups traffic with the following command:
+```bash
+keytool -genseckey -keyalg AES -alias jgroups -keystore jgroups.jceks -validity 360 -keysize 256 -deststoretype pkcs12
+oc create secret generic jgroups-keystore --from-file=jgroups.jceks=jgroups.jceks
+```
+
+Create a secret for HTTPS encryption with the following commands:
+```bash
+keytool -genkey -keyalg RSA -alias https -keystore keystore.jks -validity 360 -keysize 2048
+oc create secret generic https-keystore --from-file=keystore.jks=keystore.jks
+```
+
+## Values
+The below table describes the values supported for this Helm chart. For more information, see this chart's [values.yaml](./values.yaml) file.
+
+| Value | Definition | Default |
+| ----- | ---------- | ------- |
+| `sourceContextDir` | Directory containing a java application | `.` |
+| `sourceUri` | URI to a git repository containing a java application | `nil`, REQUIRED |
+| `sourceRef` | Branch to reference from the git repository | `master` |
+| `imageTag` | Tag to give the built image, and tag of the image to deploy | `latest` |
+| `enableTls` | Determines if JGroups and client communication should be encrypted. Requires the creation of two OpenShift secrets containing keystores | `false` |
+| `createRoute` | Determines if a route should be created to expose the application from outside the cluster | `true` |
+| `routeHostname` | Hostname of the OpenShift Route | `""` |
+| `updateStrategy` | DeploymentConfig update strategy (Available options: Rolling, Recreate) | `Rolling` |
+| `resources.requests.memory` | Application memory request | `512Mi` |
+| `resources.requests.cpu` | Application cpu request | `100m` |
+| `resources.limits.memory` | Application memory limit | `1Gi` |
+| `resources.limits.cpu` | Application cpu limit | `300m` |
+| `replicas` | Number of pods to deploy | `1` |
+| `jgroupsClusterPassword` | Password for cluster authentication. Required for EAP nodes to join a cluster | `testpass` |
+| `jgroupsEncryptPassword` | Password to the JGroups keystore. Required if `enableTls` is true | `testpass` |
+| `jgroupsEncryptName` | Name of the JGroups keystore. Required if `enableTls` is true | `jgroups` |
+| `jgroupsEncryptKeystore` | Name of the JGroups keystore file. Required if `enableTls` is true | `jgroups.jceks` |
+| `jgroupsEncryptSecret` | Name of the secret containing jgroups keystore. Required if `enableTls` is true | `jgroups-keystore` |
+| `httpsName` | Name of the https keystore. Required if `enableTls` is true | `https` |
+| `httpsPassword` | Password to the https keystore. Required if `enableTls` is true | `testpass` |
+| `httpsKeystore` | Name of the https keystore file. Required if `enableTls` is true | `keystore.jks` |

--- a/helm-charts/eap72/templates/NOTES.txt
+++ b/helm-charts/eap72/templates/NOTES.txt
@@ -1,0 +1,17 @@
+Thank you for installing the eap72 chart!
+
+{{- if .Values.enableTls }}
+The "enableTls" value has been set to "true". You must create secrets for encrypting JGroups traffic and client traffic.
+
+To encrypt JGroups traffic:
+1) keytool -genseckey -keyalg AES -alias {{ .Values.jgroupsEncryptName }} -keystore {{ .Values.jgroupsEncryptKeystore }} -validity 360 -keysize 256 -deststoretype pkcs12
+2) oc create secret generic {{ .Values.jgroupsEncryptSecret }} --from-file={{ .Values.jgroupsEncryptKeystore }}={{ .Values.jgroupsEncryptKeystore }}
+
+To encrypt client traffic:
+1) keytool -genkey -keyalg RSA -alias {{ .Values.httpsName }} -keystore {{ .Values.httpsKeystore }} -validity 360 -keysize 2048
+2) oc create secret generic https-keystore --from-file={{ .Values.httpsKeystore }}={{ .Values.httpsKeystore }}
+
+Once these secrets are created, start a new build.
+{{- end }}
+
+Run "oc start-build {{ .Release.Name }}" if your build does not start automatically. Once the image is built, a rollout will automatically begin.

--- a/helm-charts/eap72/templates/buildconfig.yaml
+++ b/helm-charts/eap72/templates/buildconfig.yaml
@@ -1,0 +1,32 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  nodeSelector: {}
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{ .Release.Name }}:{{ .Values.imageTag }}
+  source:
+    contextDir: {{ .Values.sourceContextDir }}
+    git:
+      ref: {{ .Values.sourceRef }}
+      uri: {{ required "value 'sourceUri' required" .Values.sourceUri }}
+    type: Git
+  strategy:
+    sourceStrategy:
+      env:
+        - name: MAVEN_ARGS_APPEND
+          value: -Dcom.redhat.xpaas.repo.jbossorg
+      forcePull: true
+      from:
+        kind: ImageStreamTag
+        name: jboss-eap72-openshift:1.0
+        namespace: openshift
+      incremental: true
+    type: Source
+  triggers:
+    - type: ConfigChange
+status:
+  lastVersion: 0

--- a/helm-charts/eap72/templates/deploymentconfig.yaml
+++ b/helm-charts/eap72/templates/deploymentconfig.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: {{ .Release.Name }}
+  annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    deploymentConfig: {{ .Release.Name }}
+  strategy:
+    type: {{ .Values.updateStrategy }}
+  template:
+    metadata:
+      labels:
+        application: {{ .Release.Name }}
+        deploymentConfig: {{ .Release.Name }}
+      name: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Release.Name }}
+          env:
+{{- if .Values.enableTls }}
+            - name: HTTPS_NAME
+              value: {{ .Values.httpsName }}
+            - name: HTTPS_PASSWORD
+              value: {{ .Values.httpsPassword }}
+            - name: HTTPS_KEYSTORE
+              value: {{ .Values.httpsKeystore }}
+            - name: HTTPS_KEYSTORE_DIR
+              value: /etc/eap-secret-volume
+            - name: JGROUPS_ENCRYPT_SECRET
+              value: {{ .Values.jgroupsEncryptSecret }}
+            - name: JGROUPS_ENCRYPT_KEYSTORE_DIR
+              value: /etc/jgroups-encrypt-secret-volume
+            - name: JGROUPS_ENCRYPT_KEYSTORE
+              value: {{ .Values.jgroupsEncryptKeystore }}
+            - name: JGROUPS_ENCRYPT_NAME
+              value: {{ .Values.jgroupsEncryptName }}
+            - name: JGROUPS_ENCRYPT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: jgroups-encrypt-password
+                  name: {{ .Release.Name }}
+{{- end }}
+            - name: JGROUPS_PING_PROTOCOL
+              value: dns.DNS_PING
+            - name: JGROUPS_CLUSTER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: jgroups-cluster-password
+                  name: {{ .Release.Name }}
+            - name: OPENSHIFT_DNS_PING_SERVICE_NAME
+              value: {{ .Release.Name }}-ping
+            - name: OPENSHIFT_DNS_PING_SERVICE_PORT
+              value: "8888"
+            - name: AUTO_DEPLOY_EXPLODED
+              value: "false"
+          image: {{ .Release.Name }}
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - /opt/eap/bin/livenessProbe.sh
+            initialDelaySeconds: 90
+            timeoutSeconds: 10
+          name: {{ .Release.Name }}
+          readinessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - /opt/eap/bin/readinessProbe.sh
+            initialDelaySeconds: 90
+            timeoutSeconds: 10
+          resources:
+{{ .Values.resources | toYaml | indent 12 }}
+{{- if .Values.enableTls }}
+          volumeMounts:
+            - mountPath: /etc/jgroups-encrypt-secret-volume
+              name: eap-jgroups-keystore-volume
+              readOnly: true
+            - mountPath: /etc/eap-secret-volume
+              name: eap-https-keystore-volume
+              readOnly: true
+      volumes:
+        - name: eap-jgroups-keystore-volume
+          secret:
+            secretName: {{ .Values.jgroupsEncryptSecret }}
+        - name: eap-https-keystore-volume
+          secret:
+            secretName: https-keystore
+{{- end }}
+      terminationGracePeriodSeconds: 75
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - {{ .Release.Name }}
+        from:
+          kind: ImageStreamTag
+          name: {{ .Release.Name }}:{{ .Values.imageTag }}
+      type: ImageChange
+    - type: ConfigChange

--- a/helm-charts/eap72/templates/imagestream.yaml
+++ b/helm-charts/eap72/templates/imagestream.yaml
@@ -1,0 +1,5 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: {{ .Release.Name }}
+spec: {}

--- a/helm-charts/eap72/templates/ping-service.yaml
+++ b/helm-charts/eap72/templates/ping-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-ping
+spec:
+  clusterIP: None
+  ports:
+    - name: ping
+      port: 8888
+  publishNotReadyAddresses: true
+  selector:
+    deploymentConfig: {{ .Release.Name }}

--- a/helm-charts/eap72/templates/route.yaml
+++ b/helm-charts/eap72/templates/route.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.createRoute }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  host: "{{ .Values.routeHostname }}"
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+{{- if .Values.enableTls }}
+    termination: passthrough
+{{- else }}
+    termination: edge
+{{- end }}
+  to:
+    kind: Service
+    name: {{ .Release.Name }}
+    weight: 100
+status:
+  ingress: []
+{{- end }}

--- a/helm-charts/eap72/templates/secret.yaml
+++ b/helm-charts/eap72/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}
+data:
+  jgroups-cluster-password:
+    {{ .Values.jgroupsClusterPassword | b64enc }}
+{{- if .Values.enableTls }}
+  jgroups-encrypt-password:
+    {{ .Values.jgroupsEncryptPassword | b64enc }}
+{{- end }}

--- a/helm-charts/eap72/templates/server-service.yaml
+++ b/helm-charts/eap72/templates/server-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  ports:
+{{- if .Values.enableTls }}
+    - port: 8443
+      targetPort: 8443
+{{- else }}
+    - port: 8080
+      targetPort: 8080
+{{- end }}
+  selector:
+    deploymentConfig: {{ .Release.Name }}

--- a/helm-charts/eap72/templates/tests/pod.yaml
+++ b/helm-charts/eap72/templates/tests/pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-test
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: {{ .Release.Name }}-test
+      image: registry.redhat.io/ubi8/ubi
+      imagePullPolicy: IfNotPresent
+      command:
+        - curl
+{{- if .Values.enableTls }}
+        - {{ .Release.Name }}:8443
+{{- else }}
+        - {{ .Release.Name }}:8080
+{{- end }}
+        - --max-time
+        - "10"
+  restartPolicy: Never
+    

--- a/helm-charts/eap72/values.yaml
+++ b/helm-charts/eap72/values.yaml
@@ -1,0 +1,46 @@
+## Directory containing your source code
+sourceContextDir: "."
+## URI to a git repository (REQUIRED)
+sourceUri:
+## Ref to use from git repository
+sourceRef: master
+## Tag to give the built image, and tag of the image to deploy
+imageTag: latest
+
+## Should JGroups and client communication be encrypted?
+enableTls: false
+## Create a route so the application can be access from outside the OCP cluster?
+createRoute: true
+## Hostname of the OpenShift route. If left blank, a hostname will be automatically generated in the form <release-name>-<namespace>.<suffix>
+routeHostname: ""
+
+## DeploymentConfig update strategy. (Rolling | Recreate)
+updateStrategy: Rolling
+## Application resource requests and limits
+resources:
+  requests:
+    memory: 512Mi
+    cpu: 100m
+  limits:
+    memory: 1Gi
+    cpu: 300m
+## Number of pods to deploy
+replicas: 1
+
+## Password for node-to-node EAP cluster authentication
+jgroupsClusterPassword: testpass
+## Symmetric key for encrypting node-to-node communication
+jgroupsEncryptPassword: testpass
+## Name of the jgroups keystore
+jgroupsEncryptName: jgroups
+## Name of the jgroups keystore file
+jgroupsEncryptKeystore: jgroups.jceks
+## Name of the secret that contains the jgroups keystore
+jgroupsEncryptSecret: jgroups-keystore
+
+## Name of the https keystore
+httpsName: https
+## Password to the https keystore
+httpsPassword: testpass
+## Name of the https keystore file
+httpsKeystore: keystore.jks


### PR DESCRIPTION
#### What is this PR About?
This is a simple Helm chart for deploying a Java application on EAP 7.2. This chart will deploy a BuildConfig and ImageStream for performing an s2i build. Once the image is built, it will automatically be rolled out via a DeploymentConfig image trigger. 

Users can enable TLS by providing two different OpenShift secrets, described in this chart's readme and NOTES.txt.

Future features can be added to enable SSO, add datasources, leverage service serving certificates, etc, unless requested by maintainers for this PR.

#### How do we test this?
This chart provides a test hook that will run "curl" against the application's service. Test the chart by running `helm test $RELEASE_NAME` after the EAP pod is in a ready state. The resulting output will display whether the test passed or not.

cc: @redhat-cop/day-in-the-life
