### PR TITLE
Remove rabbit build check

### DIFF
--- a/_test/rabbitmq.sh
+++ b/_test/rabbitmq.sh
@@ -19,10 +19,6 @@ applier() {
 test() {
   # Make sure we're logged in, and we've found at least one build to test.
   oc status > /dev/null || echo "Please log in before running tests." || exit 1
-  if [ $(oc get builds -n ${NAMESPACE} --no-headers | grep -c .) -lt 1 ]; then
-    echo "Did not find any builds, make sure you've passed the proper arguments."
-    exit 1
-  fi
 
   echo "Ensure build is executed..."
   for bc in $(oc get bc -n ${NAMESPACE} -o jsonpath='{.items[*].metadata.name}'); do

--- a/_test/rabbitmq.sh
+++ b/_test/rabbitmq.sh
@@ -29,13 +29,13 @@ test() {
 
   echo "Waiting for all builds to start..."
   while [[ "$(get_build_phases "New")" -ne 0 || $(get_build_phases "Pending") -ne 0 ]]; do
-    echo -ne "New Builds: $(get_build_phases "New"), Pending Builds: $(get_build_phases "Pending")"
+    echo -ne "New Builds: $(get_build_phases "New"), Pending Builds: $(get_build_phases "Pending")\r"
     sleep 1
   done
 
   echo "Waiting for build to complete..."
   while [ $(get_build_phases "Running") -ne 0 ]; do
-    echo -ne "Running Builds: $(get_build_phases "Running")"
+    echo -ne "Running Builds: $(get_build_phases "Running")\r"
     sleep 1
   done
 


### PR DESCRIPTION
#### What is this PR About?
Remove unnecessary check for builds in RabbitMQ test 

#### How do we test this?
```
./_test/rabbitmq.sh applier rabbitmq-test pabrahamsson/containers-quickstarts remove_rabbit_build_check && ./_test/rabbitmq.sh test rabbitmq-test pabrahamsson/containers-quickstarts remove_rabbit_build_check
```

cc: @redhat-cop/day-in-the-life
