### PR TITLE
Change how JVM properties are applied to allow more flexible configuration

### DIFF
--- a/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
+++ b/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
@@ -116,6 +116,10 @@ objects:
                 name: sonar-ldap-bind-dn
           - name: SONAR_SEARCH_JAVA_ADDITIONAL_OPTS
             value: '-Dnode.store.allow_mmapfs=false'
+          - name: SONAR_SAR_ADMIN_GROUP
+            value: ${SONAR_SAR_ADMIN_GROUP}
+          - name: SONAR_SAR_USER_GROUP
+            value: ${SONAR_SAR_USER_GROUP}
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3
@@ -295,3 +299,11 @@ parameters:
   - name: SONAR_SEARCH_JAVA_ADDITIONAL_OPTS
     description: Pass in additional Java opts to ElasticSearch
     displayName: Add sonar.search.javaAdditionalOpts
+  - name: SONAR_SAR_ADMIN_GROUP
+    description: Group which will be given admin privileges in SonarQube
+    displayName: OAuth Admin Group
+    value: sonar-administrators
+  - name: SONAR_SAR_USER_GROUP
+    description: Group which will be given user privileges in SonarQube
+    displayName: OAuth User Group
+    value: sonar-users

--- a/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
+++ b/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
@@ -58,6 +58,8 @@ objects:
       spec:
         containers:
         - env:
+          - name: SONAR_LOG_LEVEL
+            value: ${SONAR_LOG_LEVEL}
           - name: JDBC_URL
             value: jdbc:postgresql://sonardb:5432/sonar
           - name: JDBC_USERNAME
@@ -120,6 +122,10 @@ objects:
             value: ${SONAR_SAR_ADMIN_GROUP}
           - name: SONAR_SAR_USER_GROUP
             value: ${SONAR_SAR_USER_GROUP}
+          - name: SONAR_OPENSHIFT_OAUTH_ACCEPT_INVALID_CERTS
+            value: ${SONAR_OPENSHIFT_OAUTH_ACCEPT_INVALID_CERTS}
+          - name: SONAR_OPENSHIFT_OAUTH_CA_CERT
+            value: ${SONAR_OPENSHIFT_OAUTH_CA_CERT}
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3
@@ -307,3 +313,19 @@ parameters:
     description: Group which will be given user privileges in SonarQube
     displayName: OAuth User Group
     value: sonar-users
+  - name: SONAR_LOG_LEVEL
+    value: WARN
+    description: Log4j log level for SonarQube
+    displayName: Log level
+  - name: SONARQUBE_WEB_JVM_OPTS
+    displayName: Additional JVM options for the SonarQube web app
+    description: Addition JVM options (e.g. -Dsome.property) for the web application
+    value: -Djava.security.egd=file:/dev/./urandom
+  - name: SONAR_OPENSHIFT_OAUTH_ACCEPT_INVALID_CERTS
+    value: "false"
+    displayName: Acept all certificates for OAuth
+    description: Allow the OAuth code to ignore invalid certificates (Not for production use)
+  - name: SONAR_OPENSHIFT_OAUTH_CA_CERT
+    displayName: OpenShift Certificate Path
+    description: The certificate which will allow OAuth callbacks to be validated
+    value: /run/secrets/kubernetes.io/serviceaccount/ca.crt

--- a/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
+++ b/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
@@ -314,7 +314,7 @@ parameters:
     displayName: OAuth User Group
     value: sonar-users
   - name: SONAR_LOG_LEVEL
-    value: WARN
+    value: INFO
     description: Log4j log level for SonarQube
     displayName: Log level
   - name: SONARQUBE_WEB_JVM_OPTS

--- a/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
+++ b/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
@@ -135,7 +135,7 @@ objects:
               path: /
               port: 9000
               scheme: HTTP
-            initialDelaySeconds: ${SONAR_SERVICE_INITIAL_DELAY}
+            initialDelaySeconds: ${{SONAR_SERVICE_INITIAL_DELAY}}
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -149,7 +149,7 @@ objects:
               path: /
               port: 9000
               scheme: HTTP
-            initialDelaySeconds: ${SONAR_SERVICE_INITIAL_DELAY}
+            initialDelaySeconds: ${{SONAR_SERVICE_INITIAL_DELAY}}
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -333,6 +333,6 @@ parameters:
     description: The certificate which will allow OAuth callbacks to be validated
     value: /run/secrets/kubernetes.io/serviceaccount/ca.crt
   - name: SONAR_SERVICE_INITIAL_DELAY
-    value: 45
+    value: '45'
     description: The time to delay before the first liveness/readiness check
     displayName: Liveness/Readiness Initial Delay

--- a/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
+++ b/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
@@ -3,16 +3,16 @@ kind: Template
 metadata:
   name: "sonarqube"
 objects:
-- apiVersion: v1
-  kind: Secret
+- kind: Secret
+  apiVersion: v1
   stringData:
     password: ${SONAR_LDAP_BIND_PASSWORD}
     username: ${SONAR_LDAP_BIND_DN}
   metadata:
     name: sonar-ldap-bind-dn
   type: kubernetes.io/basic-auth
-- apiVersion: v1
-  kind: PersistentVolumeClaim
+- kind: PersistentVolumeClaim
+  apiVersion: v1
   metadata:
     name: sonarqube-data
   spec:
@@ -22,8 +22,8 @@ objects:
       requests:
         storage: ${SONARQUBE_PERSISTENT_VOLUME_SIZE}
   status: {}
-- apiVersion: v1
-  kind: DeploymentConfig
+- kind: DeploymentConfig
+  apiVersion: v1
   metadata:
     generation: 1
     labels:
@@ -58,6 +58,8 @@ objects:
       spec:
         containers:
         - env:
+          - name: JENKINS_URL
+            value: ${JENKINS_URL}
           - name: SONAR_LOG_LEVEL
             value: ${SONAR_LOG_LEVEL}
           - name: JDBC_URL
@@ -117,7 +119,7 @@ objects:
                 key: password
                 name: sonar-ldap-bind-dn
           - name: SONAR_SEARCH_JAVA_ADDITIONAL_OPTS
-            value: '-Dnode.store.allow_mmapfs=false'
+            value: ${SONAR_SEARCH_JAVA_ADDITIONAL_OPTS}
           - name: SONAR_SAR_ADMIN_GROUP
             value: ${SONAR_SAR_ADMIN_GROUP}
           - name: SONAR_SAR_USER_GROUP
@@ -179,8 +181,8 @@ objects:
           name: sonarqube:latest
       type: ImageChange
     - type: ConfigChange
-- apiVersion: v1
-  kind: Route
+- kind: Route
+  apiVersion: v1
   metadata:
     labels:
       app: sonarqube
@@ -195,8 +197,8 @@ objects:
       name: sonarqube
       weight: 100
     wildcardPolicy: None
-- apiVersion: v1
-  kind: Service
+- kind: Service
+  apiVersion: v1
   metadata:
     labels:
       app: sonarqube
@@ -211,14 +213,14 @@ objects:
       deploymentconfig: sonarqube
     sessionAffinity: None
     type: ClusterIP
-- apiVersion: v1
-  kind: ServiceAccount
+- kind: ServiceAccount
+  apiVersion: v1
   metadata:
     annotations:
       serviceaccounts.openshift.io/oauth-redirectreference.sonarqube: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"sonarqube"}}'
     name: sonarqube
-- apiVersion: v1
-  kind: RoleBinding
+- kind: RoleBinding
+  apiVersion: v1
   metadata:
     name: sonarqube_view
   roleRef:
@@ -305,6 +307,7 @@ parameters:
   - name: SONAR_SEARCH_JAVA_ADDITIONAL_OPTS
     description: Pass in additional Java opts to ElasticSearch
     displayName: Add sonar.search.javaAdditionalOpts
+    value: "-Dnode.store.allow_mmapfs=false"
   - name: SONAR_SAR_ADMIN_GROUP
     description: Group which will be given admin privileges in SonarQube
     displayName: OAuth Admin Group

--- a/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
+++ b/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
@@ -326,7 +326,7 @@ parameters:
     value: -Djava.security.egd=file:/dev/./urandom
   - name: SONAR_OPENSHIFT_OAUTH_ACCEPT_INVALID_CERTS
     value: "false"
-    displayName: Acept all certificates for OAuth
+    displayName: Accept all certificates for OAuth
     description: Allow the OAuth code to ignore invalid certificates (Not for production use)
   - name: SONAR_OPENSHIFT_OAUTH_CA_CERT
     displayName: OpenShift Certificate Path

--- a/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
+++ b/sonarqube/.openshift/templates/sonarqube-deployment-template.yml
@@ -135,7 +135,7 @@ objects:
               path: /
               port: 9000
               scheme: HTTP
-            initialDelaySeconds: 45
+            initialDelaySeconds: ${SONAR_SERVICE_INITIAL_DELAY}
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -149,7 +149,7 @@ objects:
               path: /
               port: 9000
               scheme: HTTP
-            initialDelaySeconds: 10
+            initialDelaySeconds: ${SONAR_SERVICE_INITIAL_DELAY}
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -332,3 +332,7 @@ parameters:
     displayName: OpenShift Certificate Path
     description: The certificate which will allow OAuth callbacks to be validated
     value: /run/secrets/kubernetes.io/serviceaccount/ca.crt
+  - name: SONAR_SERVICE_INITIAL_DELAY
+    value: 45
+    description: The time to delay before the first liveness/readiness check
+    displayName: Liveness/Readiness Initial Delay

--- a/sonarqube/run.sh
+++ b/sonarqube/run.sh
@@ -24,5 +24,5 @@ if [ "${1:0:1}" != '-' ]; then
 fi
 
 java -jar lib/sonar-application-$SONAR_VERSION.jar \
-    -Dsonar.web.javaAdditionalOpts="${SONARQUBE_WEB_JVM_OPTS} -Djava.security.egd=file:/dev/./urandom" \
+    -Dsonar.web.javaAdditionalOpts="-Djava.security.egd=file:/dev/./urandom ${SONARQUBE_WEB_JVM_OPTS}" \
     "$@"

--- a/sonarqube/run.sh
+++ b/sonarqube/run.sh
@@ -6,6 +6,9 @@ set -e
 ## If the mounted data volume is empty, populate it from the default data
 cp -a /opt/sonarqube/data-init/* /opt/sonarqube/data/
 
+cp ${JAVA_HOME}/lib/security/cacerts /tmp/cacerts
+${JAVA_HOME}/bin/keytool -import -noprompt -keystore /tmp/cacerts -file /run/secrets/kubernetes.io/serviceaccount/ca.crt -storepass changeit -alias openshift
+
 ## Link the plugins directory from the mounted volume
 rm -rf /opt/sonarqube/extensions/plugins
 ln -s /opt/sonarqube/data/plugins /opt/sonarqube/extensions/plugins
@@ -23,5 +26,5 @@ if [ "${1:0:1}" != '-' ]; then
   exec "$@"
 fi
 
-java -jar lib/sonar-application-$SONAR_VERSION.jar \
+java -jar lib/sonar-application-$SONAR_VERSION.jar -Djavax.net.ssl.trustStore=/tmp/cacerts \
     "$@"

--- a/sonarqube/run.sh
+++ b/sonarqube/run.sh
@@ -24,4 +24,4 @@ if [ "${1:0:1}" != '-' ]; then
 fi
 
 java -jar lib/sonar-application-$SONAR_VERSION.jar \
-    "$@"
+    "$@" -dsonar.web.javaAdditionalOpts="${SONARQUBE_WEB_JVM_OPTS}"

--- a/sonarqube/run.sh
+++ b/sonarqube/run.sh
@@ -6,9 +6,6 @@ set -e
 ## If the mounted data volume is empty, populate it from the default data
 cp -a /opt/sonarqube/data-init/* /opt/sonarqube/data/
 
-cp ${JAVA_HOME}/lib/security/cacerts /tmp/cacerts
-${JAVA_HOME}/bin/keytool -import -noprompt -keystore /tmp/cacerts -file /run/secrets/kubernetes.io/serviceaccount/ca.crt -storepass changeit -alias openshift
-
 ## Link the plugins directory from the mounted volume
 rm -rf /opt/sonarqube/extensions/plugins
 ln -s /opt/sonarqube/data/plugins /opt/sonarqube/extensions/plugins
@@ -26,5 +23,5 @@ if [ "${1:0:1}" != '-' ]; then
   exec "$@"
 fi
 
-java -jar lib/sonar-application-$SONAR_VERSION.jar -Djavax.net.ssl.trustStore=/tmp/cacerts \
+java -jar lib/sonar-application-$SONAR_VERSION.jar \
     "$@"

--- a/sonarqube/run.sh
+++ b/sonarqube/run.sh
@@ -24,5 +24,4 @@ if [ "${1:0:1}" != '-' ]; then
 fi
 
 java -jar lib/sonar-application-$SONAR_VERSION.jar \
-    -Dsonar.web.javaAdditionalOpts="-Djava.security.egd=file:/dev/./urandom ${SONARQUBE_WEB_JVM_OPTS}" \
     "$@"

--- a/sonarqube/run.sh
+++ b/sonarqube/run.sh
@@ -24,4 +24,4 @@ if [ "${1:0:1}" != '-' ]; then
 fi
 
 java -jar lib/sonar-application-$SONAR_VERSION.jar \
-    "$@" -dsonar.web.javaAdditionalOpts="${SONARQUBE_WEB_JVM_OPTS}"
+    "$@" -Dsonar.web.javaAdditionalOpts="${SONARQUBE_WEB_JVM_OPTS}"

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -7,6 +7,7 @@ sonar.authenticator.createUsers=${env:SONAR_AUTOCREATE_USERS}
 sonar.log.level=${env:SONAR_LOG_LEVEL}
 sonar.search.javaAdditionalOpts=${env:SONAR_SEARCH_JAVA_ADDITIONAL_OPTS}
 ignore.certs=${env:SONAR_OPENSHIFT_OAUTH_ACCEPT_INVALID_CERTS}
+oauth.cert=${env:SONAR_OPENSHIFT_OAUTH_CA_CERT}
 sonar.auth.openshift.sar.groups=${SONAR_SAR_ADMIN_GROUP}=sonar-administrators,${SONAR_SAR_USER_GROUP}=sonar-users
 sonar.web.javaAdditionalOpts=${env:SONARQUBE_WEB_JVM_OPTS}
 http.proxyHost=${env:PROXY_HOST}
@@ -29,3 +30,4 @@ ldap.group.request=${env:LDAP_GROUP_REQUEST}
 ldap.group.idAttribute=${env:LDAP_GROUP_ID_ATTR}
 kubernetes.service=https://${env:KUBERNETES_SERVICE_HOST}:${env:KUBERNETES_SERVICE_PORT}/
 sonar.auth.openshift.isEnabled=true
+javax.net.ssl.trustStore=/tmp/cacerts

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -7,7 +7,8 @@ sonar.authenticator.createUsers=${env:SONAR_AUTOCREATE_USERS}
 sonar.log.level=${env:SONAR_LOG_LEVEL}
 sonar.search.javaAdditionalOpts=${env:SONAR_SEARCH_JAVA_ADDITIONAL_OPTS}
 ignore.certs=true
-sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom -Dsonar.auth.openshift.sar.groups=${SONAR_SAR_ADMIN_GROUP}=sonar-administrators,${SONAR_SAR_USER_GROUP}=sonar-users ${env:SONARQUBE_WEB_JVM_OPTS}
+sonar.auth.openshift.sar.groups=${SONAR_SAR_ADMIN_GROUP}=sonar-administrators,${SONAR_SAR_USER_GROUP}=sonar-users
+sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom ${env:SONARQUBE_WEB_JVM_OPTS}
 http.proxyHost=${env:PROXY_HOST}
 http.proxyPort=${env:PROXY_PORT}
 http.proxyUser=${env:PROXY_USER}

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -6,6 +6,7 @@ sonar.forceAuthentication=${env:FORCE_AUTHENTICATION}
 sonar.authenticator.createUsers=${env:SONAR_AUTOCREATE_USERS}
 sonar.log.level=${env:SONAR_LOG_LEVEL}
 sonar.search.javaAdditionalOpts=${env:SONAR_SEARCH_JAVA_ADDITIONAL_OPTS}
+sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom ${env:SONARQUBE_WEB_JVM_OPTS}
 http.proxyHost=${env:PROXY_HOST}
 http.proxyPort=${env:PROXY_PORT}
 http.proxyUser=${env:PROXY_USER}

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -6,7 +6,7 @@ sonar.forceAuthentication=${env:FORCE_AUTHENTICATION}
 sonar.authenticator.createUsers=${env:SONAR_AUTOCREATE_USERS}
 sonar.log.level=${env:SONAR_LOG_LEVEL}
 sonar.search.javaAdditionalOpts=${env:SONAR_SEARCH_JAVA_ADDITIONAL_OPTS}
-sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom -Dsonar.auth.openshift.sar.groups=ocp-admin=${SONAR_SAR_ADMIN_GROUP},ocp-users=${SONAR_SAR_USER_GROUP} ${env:SONARQUBE_WEB_JVM_OPTS}
+sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom -Dsonar.auth.openshift.sar.groups=${SONAR_SAR_ADMIN_GROUP}=sonar-administrators,${SONAR_SAR_USER_GROUP}=sonar-users ${env:SONARQUBE_WEB_JVM_OPTS}
 http.proxyHost=${env:PROXY_HOST}
 http.proxyPort=${env:PROXY_PORT}
 http.proxyUser=${env:PROXY_USER}

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -27,3 +27,4 @@ ldap.group.request=${env:LDAP_GROUP_REQUEST}
 ldap.group.idAttribute=${env:LDAP_GROUP_ID_ATTR}
 kubernetes.service=https://${env:KUBERNETES_SERVICE_HOST}:${env:KUBERNETES_SERVICE_PORT}/
 sonar.auth.openshift.isEnabled=true
+sonar.auth.openshift.sar.groups=ocp-admin=${SONAR_SAR_ADMIN_GROUP},ocp-users=${SONAR_SAR_USER_GROUP}

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -6,7 +6,7 @@ sonar.forceAuthentication=${env:FORCE_AUTHENTICATION}
 sonar.authenticator.createUsers=${env:SONAR_AUTOCREATE_USERS}
 sonar.log.level=${env:SONAR_LOG_LEVEL}
 sonar.search.javaAdditionalOpts=${env:SONAR_SEARCH_JAVA_ADDITIONAL_OPTS}
-sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom ${env:SONARQUBE_WEB_JVM_OPTS}
+sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom -Dsonar.auth.openshift.sar.groups=ocp-admin=${SONAR_SAR_ADMIN_GROUP},ocp-users=${SONAR_SAR_USER_GROUP} ${env:SONARQUBE_WEB_JVM_OPTS}
 http.proxyHost=${env:PROXY_HOST}
 http.proxyPort=${env:PROXY_PORT}
 http.proxyUser=${env:PROXY_USER}
@@ -27,4 +27,3 @@ ldap.group.request=${env:LDAP_GROUP_REQUEST}
 ldap.group.idAttribute=${env:LDAP_GROUP_ID_ATTR}
 kubernetes.service=https://${env:KUBERNETES_SERVICE_HOST}:${env:KUBERNETES_SERVICE_PORT}/
 sonar.auth.openshift.isEnabled=true
-sonar.auth.openshift.sar.groups=ocp-admin=${SONAR_SAR_ADMIN_GROUP},ocp-users=${SONAR_SAR_USER_GROUP}

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -8,7 +8,7 @@ sonar.log.level=${env:SONAR_LOG_LEVEL}
 sonar.search.javaAdditionalOpts=${env:SONAR_SEARCH_JAVA_ADDITIONAL_OPTS}
 ignore.certs=${env:SONAR_OPENSHIFT_OAUTH_ACCEPT_INVALID_CERTS}
 oauth.cert=${env:SONAR_OPENSHIFT_OAUTH_CA_CERT}
-sonar.auth.openshift.sar.groups=${SONAR_SAR_ADMIN_GROUP}=sonar-administrators,${SONAR_SAR_USER_GROUP}=sonar-users
+sonar.auth.openshift.sar.groups=${env:SONAR_SAR_ADMIN_GROUP}=sonar-administrators,${env:SONAR_SAR_USER_GROUP}=sonar-users
 http.proxyHost=${env:PROXY_HOST}
 http.proxyPort=${env:PROXY_PORT}
 http.proxyUser=${env:PROXY_USER}

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -9,7 +9,6 @@ sonar.search.javaAdditionalOpts=${env:SONAR_SEARCH_JAVA_ADDITIONAL_OPTS}
 ignore.certs=${env:SONAR_OPENSHIFT_OAUTH_ACCEPT_INVALID_CERTS}
 oauth.cert=${env:SONAR_OPENSHIFT_OAUTH_CA_CERT}
 sonar.auth.openshift.sar.groups=${SONAR_SAR_ADMIN_GROUP}=sonar-administrators,${SONAR_SAR_USER_GROUP}=sonar-users
-sonar.web.javaAdditionalOpts=${env:SONARQUBE_WEB_JVM_OPTS}
 http.proxyHost=${env:PROXY_HOST}
 http.proxyPort=${env:PROXY_PORT}
 http.proxyUser=${env:PROXY_USER}

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -30,4 +30,3 @@ ldap.group.request=${env:LDAP_GROUP_REQUEST}
 ldap.group.idAttribute=${env:LDAP_GROUP_ID_ATTR}
 kubernetes.service=https://${env:KUBERNETES_SERVICE_HOST}:${env:KUBERNETES_SERVICE_PORT}/
 sonar.auth.openshift.isEnabled=true
-javax.net.ssl.trustStore=/tmp/cacerts

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -6,9 +6,9 @@ sonar.forceAuthentication=${env:FORCE_AUTHENTICATION}
 sonar.authenticator.createUsers=${env:SONAR_AUTOCREATE_USERS}
 sonar.log.level=${env:SONAR_LOG_LEVEL}
 sonar.search.javaAdditionalOpts=${env:SONAR_SEARCH_JAVA_ADDITIONAL_OPTS}
-ignore.certs=true
+ignore.certs=${env:SONAR_OPENSHIFT_OAUTH_ACCEPT_INVALID_CERTS}
 sonar.auth.openshift.sar.groups=${SONAR_SAR_ADMIN_GROUP}=sonar-administrators,${SONAR_SAR_USER_GROUP}=sonar-users
-sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom ${env:SONARQUBE_WEB_JVM_OPTS}
+sonar.web.javaAdditionalOpts=${env:SONARQUBE_WEB_JVM_OPTS}
 http.proxyHost=${env:PROXY_HOST}
 http.proxyPort=${env:PROXY_PORT}
 http.proxyUser=${env:PROXY_USER}

--- a/sonarqube/sonar.properties
+++ b/sonarqube/sonar.properties
@@ -6,6 +6,7 @@ sonar.forceAuthentication=${env:FORCE_AUTHENTICATION}
 sonar.authenticator.createUsers=${env:SONAR_AUTOCREATE_USERS}
 sonar.log.level=${env:SONAR_LOG_LEVEL}
 sonar.search.javaAdditionalOpts=${env:SONAR_SEARCH_JAVA_ADDITIONAL_OPTS}
+ignore.certs=true
 sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom -Dsonar.auth.openshift.sar.groups=${SONAR_SAR_ADMIN_GROUP}=sonar-administrators,${SONAR_SAR_USER_GROUP}=sonar-users ${env:SONARQUBE_WEB_JVM_OPTS}
 http.proxyHost=${env:PROXY_HOST}
 http.proxyPort=${env:PROXY_PORT}


### PR DESCRIPTION
#### What is this PR About?
When the environment variable `SONARQUBE_WEB_JVM_OPTS` is undefined, the application will not start because there is an extra space between the property name and the next property value.

#### How do we test this?


1. get MR code on your machine

1. following instructions in [README](https://github.com/redhat-cop/containers-quickstarts/tree/master/sonarqube)

1. then, since this repo will point the build to the master branch, run a new build

```oc start-build sonarqube --from-dir=.. -n sonarqube```

1. Go to sonar home page. There should now be a 'login with OpenShift link'
1. You should be redirected to the OpenShift login screen. --> Login.
1. You should be redirected to Sonarqube and see the projects page (empty)

Resolves #282 

cc: @redhat-cop/day-in-the-life
