### PR TITLE
Various UX improvements and bug fixes to eap72 chart.

### DIFF
--- a/helm-charts/eap72/README.md
+++ b/helm-charts/eap72/README.md
@@ -1,8 +1,8 @@
 # EAP 7.2 Helm Chart
-A Helm chart for deploying an EAP application to OpenShift.
+A Helm chart for building and deploying an EAP application to OpenShift, inspired by the [OpenShift EAP templates](https://github.com/jboss-openshift/application-templates/tree/master/eap).
 
 ## Installation
-Users must provide a "sourceUri" value, which should point to a git repository containing a Java application. Run the installation with the following command.
+Users must provide a "sourceUri" value, which should point to a git repository containing a Java application. This location will be used as the source location for the s2i build. Run the installation with the following command.
 ```bash
 helm install my-eap-application . --set sourceUri=repository-uri
 ```
@@ -16,32 +16,33 @@ oc start-build $RELEASE_NAME
 The appliction will be automatically rolled out when the build finishes.
 
 ## Enabling TLS
-TLS can be enabled with the "enableTls" value. Communication within the cluster will be encrypted when this value is set to "true". Traffic from outside of the cluster is encrypted regardless of this value's setting.
+TLS can be enabled with the "tls.enabled" value. Communication within the cluster will be encrypted when this value is set to "true". Traffic from outside of the cluster is encrypted regardless of this value's setting.
 
 Users must provide a secret containing a JGroups keystore and a secret containing an keystore for client traffic. 
 
-Create a JGroups traffic with the following command:
+Create a JGroups traffic secret by following the example below:
 ```bash
-keytool -genseckey -keyalg AES -alias jgroups -keystore jgroups.jceks -validity 360 -keysize 256 -deststoretype pkcs12
+keytool -genseckey -keyalg AES -alias jgroups -keystore jgroups.jceks -validity 360 -keysize 256 -deststoretype jceks
 oc create secret generic jgroups-keystore --from-file=jgroups.jceks=jgroups.jceks
 ```
 
-Create a secret for HTTPS encryption with the following commands:
+Create a secret for HTTPS encryption by following the example below:
 ```bash
 keytool -genkey -keyalg RSA -alias https -keystore keystore.jks -validity 360 -keysize 2048
 oc create secret generic https-keystore --from-file=keystore.jks=keystore.jks
 ```
 
+These instructions will also be displayed upon installing the chart with the "tls.enabled" value set to "true".
+
 ## Values
-The below table describes the values supported for this Helm chart. For more information, see this chart's [values.yaml](./values.yaml) file.
+The below table describes the values supported for this Helm chart. When relevant, these values are given the same name as the DeploymentConfig environment variables that they configure. See the [values.yaml](./values.yaml) file for more information on this chart's values.
 
 | Value | Definition | Default |
 | ----- | ---------- | ------- |
-| `sourceContextDir` | Directory containing a java application | `.` |
 | `sourceUri` | URI to a git repository containing a java application | `nil`, REQUIRED |
 | `sourceRef` | Branch to reference from the git repository | `master` |
+| `sourceContextDir` | Directory containing a java application | `.` |
 | `imageTag` | Tag to give the built image, and tag of the image to deploy | `latest` |
-| `enableTls` | Determines if JGroups and client communication should be encrypted. Requires the creation of two OpenShift secrets containing keystores | `false` |
 | `createRoute` | Determines if a route should be created to expose the application from outside the cluster | `true` |
 | `routeHostname` | Hostname of the OpenShift Route | `""` |
 | `updateStrategy` | DeploymentConfig update strategy (Available options: Rolling, Recreate) | `Rolling` |
@@ -51,10 +52,12 @@ The below table describes the values supported for this Helm chart. For more inf
 | `resources.limits.cpu` | Application cpu limit | `300m` |
 | `replicas` | Number of pods to deploy | `1` |
 | `jgroupsClusterPassword` | Password for cluster authentication. Required for EAP nodes to join a cluster | `testpass` |
-| `jgroupsEncryptPassword` | Password to the JGroups keystore. Required if `enableTls` is true | `testpass` |
-| `jgroupsEncryptName` | Name of the JGroups keystore. Required if `enableTls` is true | `jgroups` |
-| `jgroupsEncryptKeystore` | Name of the JGroups keystore file. Required if `enableTls` is true | `jgroups.jceks` |
-| `jgroupsEncryptSecret` | Name of the secret containing jgroups keystore. Required if `enableTls` is true | `jgroups-keystore` |
-| `httpsName` | Name of the https keystore. Required if `enableTls` is true | `https` |
-| `httpsPassword` | Password to the https keystore. Required if `enableTls` is true | `testpass` |
-| `httpsKeystore` | Name of the https keystore file. Required if `enableTls` is true | `keystore.jks` |
+| `tls.enabled` | Determines if JGroups and client communication should be encrypted. Requires the creation of two OpenShift secrets containing keystores | `false` |
+| `tls.jgroupsEncryptSecret` | Name of the secret containing jgroups keystore. Required if `tls.enabled` is true | `jgroups-keystore` |
+| `tls.jgroupsEncryptKeystore` | Name of the JGroups keystore file. Required if `tls.enabled` is true | `jgroups.jceks` |
+| `tls.jgroupsEncryptName` | Name of the JGroups keystore. Required if `tls.enabled` is true | `jgroups` |
+| `tls.jgroupsEncryptPassword` | Password to the JGroups keystore. Required if `tls.enabled` is true | `changeit` |
+| `tls.httpsSecret` | Name of the secret containing https keystore. Required if `tls.enabled` is true | `https-keystore` |
+| `tls.httpsKeystore` | Name of the https keystore file. Required if `tls.enabled` is true | `keystore.jks` |
+| `tls.httpsName` | Name of the https keystore. Required if `tls.enabled` is true | `https` |
+| `tls.httpsPassword` | Password to the https keystore. Required if `tls.enabled` is true | `changeit` |

--- a/helm-charts/eap72/templates/NOTES.txt
+++ b/helm-charts/eap72/templates/NOTES.txt
@@ -1,17 +1,19 @@
 Thank you for installing the eap72 chart!
 
-{{- if .Values.enableTls }}
-The "enableTls" value has been set to "true". You must create secrets for encrypting JGroups traffic and client traffic.
+{{- if .Values.tls.enabled }}
+The "tls.enabled" value has been set to "true". You must create secrets for encrypting JGroups traffic and client traffic.
 
 To encrypt JGroups traffic:
-1) keytool -genseckey -keyalg AES -alias {{ .Values.jgroupsEncryptName }} -keystore {{ .Values.jgroupsEncryptKeystore }} -validity 360 -keysize 256 -deststoretype pkcs12
-2) oc create secret generic {{ .Values.jgroupsEncryptSecret }} --from-file={{ .Values.jgroupsEncryptKeystore }}={{ .Values.jgroupsEncryptKeystore }}
+1) keytool -genseckey -keyalg AES -alias {{ .Values.tls.jgroupsEncryptName }} -keystore {{ .Values.tls.jgroupsEncryptKeystore }} -validity 360 -keysize 256 -deststoretype jceks
+2) oc create secret generic {{ .Values.tls.jgroupsEncryptSecret }} --from-file={{ .Values.tls.jgroupsEncryptKeystore }}={{ .Values.tls.jgroupsEncryptKeystore }}
 
 To encrypt client traffic:
-1) keytool -genkey -keyalg RSA -alias {{ .Values.httpsName }} -keystore {{ .Values.httpsKeystore }} -validity 360 -keysize 2048
-2) oc create secret generic https-keystore --from-file={{ .Values.httpsKeystore }}={{ .Values.httpsKeystore }}
+1) keytool -genkey -keyalg RSA -alias {{ .Values.tls.httpsName }} -keystore {{ .Values.tls.httpsKeystore }} -validity 360 -keysize 2048
+2) oc create secret generic {{ .Values.tls.httpsSecret }} --from-file={{ .Values.tls.httpsKeystore }}={{ .Values.tls.httpsKeystore }}
+
+If you choose a different keystore password other than "changeit", be sure to modify the "jgroupsEncryptPassword" or the "httpsPassword" values depending on the respective keystore password.
 
 Once these secrets are created, start a new build.
 {{- end }}
 
-Run "oc start-build {{ .Release.Name }}" if your build does not start automatically. Once the image is built, a rollout will automatically begin.
+Run "oc start-build {{ .Release.Name }} --follow" to start and follow your build. A rollout will automatically begin once the build is finished.

--- a/helm-charts/eap72/templates/buildconfig.yaml
+++ b/helm-charts/eap72/templates/buildconfig.yaml
@@ -26,7 +26,6 @@ spec:
         namespace: openshift
       incremental: true
     type: Source
-  triggers:
-    - type: ConfigChange
+  triggers: []
 status:
   lastVersion: 0

--- a/helm-charts/eap72/templates/deploymentconfig.yaml
+++ b/helm-charts/eap72/templates/deploymentconfig.yaml
@@ -20,23 +20,26 @@ spec:
       containers:
         - name: {{ .Release.Name }}
           env:
-{{- if .Values.enableTls }}
+{{- if .Values.tls.enabled }}
             - name: HTTPS_NAME
-              value: {{ .Values.httpsName }}
+              value: {{ .Values.tls.httpsName }}
             - name: HTTPS_PASSWORD
-              value: {{ .Values.httpsPassword }}
+              valueFrom:
+                secretKeyRef:
+                  key: https-encrypt-password
+                  name: {{ .Release.Name }}
             - name: HTTPS_KEYSTORE
-              value: {{ .Values.httpsKeystore }}
+              value: {{ .Values.tls.httpsKeystore }}
             - name: HTTPS_KEYSTORE_DIR
               value: /etc/eap-secret-volume
             - name: JGROUPS_ENCRYPT_SECRET
-              value: {{ .Values.jgroupsEncryptSecret }}
+              value: {{ .Values.tls.jgroupsEncryptSecret }}
             - name: JGROUPS_ENCRYPT_KEYSTORE_DIR
               value: /etc/jgroups-encrypt-secret-volume
             - name: JGROUPS_ENCRYPT_KEYSTORE
-              value: {{ .Values.jgroupsEncryptKeystore }}
+              value: {{ .Values.tls.jgroupsEncryptKeystore }}
             - name: JGROUPS_ENCRYPT_NAME
-              value: {{ .Values.jgroupsEncryptName }}
+              value: {{ .Values.tls.jgroupsEncryptName }}
             - name: JGROUPS_ENCRYPT_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -77,7 +80,7 @@ spec:
             timeoutSeconds: 10
           resources:
 {{ .Values.resources | toYaml | indent 12 }}
-{{- if .Values.enableTls }}
+{{- if .Values.tls.enabled }}
           volumeMounts:
             - mountPath: /etc/jgroups-encrypt-secret-volume
               name: eap-jgroups-keystore-volume
@@ -88,10 +91,10 @@ spec:
       volumes:
         - name: eap-jgroups-keystore-volume
           secret:
-            secretName: {{ .Values.jgroupsEncryptSecret }}
+            secretName: {{ .Values.tls.jgroupsEncryptSecret }}
         - name: eap-https-keystore-volume
           secret:
-            secretName: https-keystore
+            secretName: {{ .Values.tls.httpsSecret }}
 {{- end }}
       terminationGracePeriodSeconds: 75
   triggers:

--- a/helm-charts/eap72/templates/route.yaml
+++ b/helm-charts/eap72/templates/route.yaml
@@ -7,7 +7,7 @@ spec:
   host: "{{ .Values.routeHostname }}"
   tls:
     insecureEdgeTerminationPolicy: Redirect
-{{- if .Values.enableTls }}
+{{- if .Values.tls.enabled }}
     termination: passthrough
 {{- else }}
     termination: edge

--- a/helm-charts/eap72/templates/secret.yaml
+++ b/helm-charts/eap72/templates/secret.yaml
@@ -5,7 +5,9 @@ metadata:
 data:
   jgroups-cluster-password:
     {{ .Values.jgroupsClusterPassword | b64enc }}
-{{- if .Values.enableTls }}
+{{- if .Values.tls.enabled }}
   jgroups-encrypt-password:
-    {{ .Values.jgroupsEncryptPassword | b64enc }}
+    {{ .Values.tls.jgroupsEncryptPassword | b64enc }}
+  https-encrypt-password:
+    {{ .Values.tls.httpsPassword | b64enc }}
 {{- end }}

--- a/helm-charts/eap72/templates/server-service.yaml
+++ b/helm-charts/eap72/templates/server-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}
 spec:
   ports:
-{{- if .Values.enableTls }}
+{{- if .Values.tls.enabled }}
     - port: 8443
       targetPort: 8443
 {{- else }}

--- a/helm-charts/eap72/templates/tests/pod.yaml
+++ b/helm-charts/eap72/templates/tests/pod.yaml
@@ -11,7 +11,7 @@ spec:
       imagePullPolicy: IfNotPresent
       command:
         - curl
-{{- if .Values.enableTls }}
+{{- if .Values.tls.enabled }}
         - {{ .Release.Name }}:8443
 {{- else }}
         - {{ .Release.Name }}:8080

--- a/helm-charts/eap72/values.yaml
+++ b/helm-charts/eap72/values.yaml
@@ -1,14 +1,12 @@
-## Directory containing your source code
-sourceContextDir: "."
 ## URI to a git repository (REQUIRED)
 sourceUri:
 ## Ref to use from git repository
 sourceRef: master
+## Directory containing your source code
+sourceContextDir: "."
 ## Tag to give the built image, and tag of the image to deploy
 imageTag: latest
 
-## Should JGroups and client communication be encrypted?
-enableTls: false
 ## Create a route so the application can be access from outside the OCP cluster?
 createRoute: true
 ## Hostname of the OpenShift route. If left blank, a hostname will be automatically generated in the form <release-name>-<namespace>.<suffix>
@@ -29,18 +27,26 @@ replicas: 1
 
 ## Password for node-to-node EAP cluster authentication
 jgroupsClusterPassword: testpass
-## Symmetric key for encrypting node-to-node communication
-jgroupsEncryptPassword: testpass
-## Name of the jgroups keystore
-jgroupsEncryptName: jgroups
-## Name of the jgroups keystore file
-jgroupsEncryptKeystore: jgroups.jceks
-## Name of the secret that contains the jgroups keystore
-jgroupsEncryptSecret: jgroups-keystore
 
-## Name of the https keystore
-httpsName: https
-## Password to the https keystore
-httpsPassword: testpass
-## Name of the https keystore file
-httpsKeystore: keystore.jks
+tls:
+  ## Should JGroups and end-to-end client communication be encrypted?
+  ## If "true", requires a keystore for JGroups and a keystore for HTTPS
+  ## If "true", creates a passthrough route. If "false", creates an edge-terminated route.
+  enabled: false
+
+  ## Name of the secret that contains the jgroups keystore
+  jgroupsEncryptSecret: jgroups-keystore
+  ## Name of the jgroups keystore file
+  jgroupsEncryptKeystore: jgroups.jceks
+  ## Name of the jgroups keystore
+  jgroupsEncryptName: jgroups
+  ## Password to the jgroups keystore
+  jgroupsEncryptPassword: changeit
+
+  httpsSecret: https-keystore
+  ## Name of the https keystore file
+  httpsKeystore: keystore.jks
+  ## Name of the https keystore
+  httpsName: https
+  ## Password to the https keystore
+  httpsPassword: changeit


### PR DESCRIPTION
#### What is this PR About?
Improving EAP72 Helm chart by adding ux enhancements and bug fixes.

Changes include:
- Changing jgroups keystore from pkcs12 to jceks (was causing "Invalid keystore format" errors)
- Disabling bc triggers (was causing a confusing user experience because the initial installation was auto-triggering, but upgrades were not)
- Grouping all tls-related values under a `tls` map
- Adding tls.httpsSecret value (default to https-keystore)
- Saving https keystore secret in OCP secret
- Changing default keystore password to "changeit"
- Various README edits

#### How do we test this?
"helm test" command after installing the chart to an ocp cluster

cc: @redhat-cop/day-in-the-life
