### PR TITLE
ubi8-git and ubi8-google-api-python-client - init add

### DIFF
--- a/ubi8-git/.openshift/bc-ubi8-git.yml
+++ b/ubi8-git/.openshift/bc-ubi8-git.yml
@@ -1,0 +1,53 @@
+---
+apiVersion: v1
+kind: Template
+labels:
+  template: ubi8-git
+metadata:
+  annotations:
+    description: Git utility image
+    tags: git, ubi8
+  name: ubi8-git
+objects:
+- apiVersion: "v1"
+  kind: "BuildConfig"
+  metadata:
+    name: "ubi8-git"
+  spec:
+    output:
+      to:
+        kind: "ImageStreamTag"
+        name: "ubi8-git:latest"
+    source:
+      contextDir: "${CONTEXT_DIR}"
+      git:
+        uri: "${SOURCE_REPOSITORY_URL}"
+        ref: "${SOURCE_REPOSITORY_REF}"
+    strategy:
+      dockerStrategy:
+        dockerfilePath: Dockerfile
+    resources:
+      requests: 
+        cpu: 1
+        memory: "512Mi"
+      limits:
+        cpu: 2
+        memory: "1Gi"
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: ubi8-git
+  spec:
+    lookupPolicy:
+      local: true
+parameters:
+- description: Path within Git repository to build; empty for root of repository
+  name: CONTEXT_DIR
+  value: ubi8-git
+- description: Git branch/tag reference
+  name: SOURCE_REPOSITORY_REF
+  value: master
+- description: Git source URL for application
+  name: SOURCE_REPOSITORY_URL
+  required: true
+  value: https://github.com/redhat-cop/containers-quickstarts

--- a/ubi8-git/Dockerfile
+++ b/ubi8-git/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubi8
+
+LABEL maintainer="Red Hat Services"
+
+# Update image
+RUN dnf update -y && rm -rf /var/cache/yum
+
+# Install packages
+RUN dnf install -y \
+  git \
+  && dnf clean all

--- a/ubi8-git/README.md
+++ b/ubi8-git/README.md
@@ -1,0 +1,3 @@
+# ubi8-git
+
+A utility image that is the UBI8 image + git. Useful for use in things like GitLab CI pipelines where you want to use a UBI based image and need access to git.

--- a/ubi8-google-api-python-client/.openshift/bc-ubi8-google-api-python-client.yml
+++ b/ubi8-google-api-python-client/.openshift/bc-ubi8-google-api-python-client.yml
@@ -1,0 +1,53 @@
+---
+apiVersion: v1
+kind: Template
+labels:
+  template: ubi8-google-api-python-client
+metadata:
+  annotations:
+    description: google-api-python-client utility image
+    tags: git, ubi8
+  name: ubi8-google-api-python-client
+objects:
+- apiVersion: "v1"
+  kind: "BuildConfig"
+  metadata:
+    name: "ubi8-google-api-python-client"
+  spec:
+    output:
+      to:
+        kind: "ImageStreamTag"
+        name: "ubi8-google-api-python-client:latest"
+    source:
+      contextDir: "${CONTEXT_DIR}"
+      git:
+        uri: "${SOURCE_REPOSITORY_URL}"
+        ref: "${SOURCE_REPOSITORY_REF}"
+    strategy:
+      dockerStrategy:
+        dockerfilePath: Dockerfile
+    resources:
+      requests: 
+        cpu: 1
+        memory: "512Mi"
+      limits:
+        cpu: 2
+        memory: "1Gi"
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: ubi8-google-api-python-client
+  spec:
+    lookupPolicy:
+      local: true
+parameters:
+- description: Path within Git repository to build; empty for root of repository
+  name: CONTEXT_DIR
+  value: ubi8-google-api-python-client
+- description: Git branch/tag reference
+  name: SOURCE_REPOSITORY_REF
+  value: master
+- description: Git source URL for application
+  name: SOURCE_REPOSITORY_URL
+  required: true
+  value: https://github.com/redhat-cop/containers-quickstarts

--- a/ubi8-google-api-python-client/Dockerfile
+++ b/ubi8-google-api-python-client/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubi8
+
+LABEL maintainer="Red Hat Services"
+
+# Update image
+RUN dnf update -y && rm -rf /var/cache/yum
+
+# Install packages
+RUN dnf install -y \
+  git \
+  python36 \
+  python3-pip \
+  python3-numpy \
+  python3-scipy \
+  python3-setuptools \
+  python3-six \
+  && dnf clean all
+
+# Install Python modules
+RUN pip3 install --upgrade \
+  pip \
+  google-api-python-client \
+  google-auth-httplib2 \
+  google-auth-oauthlib \
+  oauth2client

--- a/ubi8-google-api-python-client/README.md
+++ b/ubi8-google-api-python-client/README.md
@@ -1,0 +1,3 @@
+# ubi8-google-api-python-client
+
+A utility image that is the UBI8 image the [google-api-python-client](https://github.com/googleapis/google-api-python-client) and dependent libraries. Useful for use in things like GitLab CI pipelines where you want to use a UBI based image and need access to the Google API.


### PR DESCRIPTION
#### What is this PR About?
Adds two utility images useful for use in GitLab CI pipelines, but could be used in other places to.

#### How do we test this?
You could build the docker image and run it if you like. We are using these images in an internal pipeline at the moment but thought it best to share them with the world.

cc: @redhat-cop/day-in-the-life
