### PR TITLE
Ubi8 asciidoctor

### DIFF
--- a/ubi8-asciidoctor/.openshift/bc-ubi8-asciidoctor.yml
+++ b/ubi8-asciidoctor/.openshift/bc-ubi8-asciidoctor.yml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: Template
+labels:
+  template: ubi8-asciidoctor
+metadata:
+  labels:
+    app.kubernetes.io/name: ubi8-asciidoctor
+    app.kubernetes.io/version: "1.2.0"
+  annotations:
+    description: asciidoctor utility image
+    tags: asciidoctor, ubi8
+  name: ubi8-asciidoctor
+objects:
+- apiVersion: "v1"
+  kind: "BuildConfig"
+  metadata:
+    name: "ubi8-asciidoctor"
+  spec:
+    output:
+      to:
+        kind: "ImageStreamTag"
+        name: "ubi8-asciidoctor:latest"
+    source:
+      contextDir: "${CONTEXT_DIR}"
+      git:
+        uri: "${SOURCE_REPOSITORY_URL}"
+        ref: "${SOURCE_REPOSITORY_REF}"
+    strategy:
+      dockerStrategy:
+        dockerfilePath: Dockerfile
+    resources:
+      requests: 
+        cpu: 1
+        memory: "512Mi"
+      limits:
+        cpu: 2
+        memory: "1Gi"
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: ubi8-asciidoctor
+  spec:
+    lookupPolicy:
+      local: true
+parameters:
+- description: Path within Git repository to build; empty for root of repository
+  name: CONTEXT_DIR
+  value: ubi8-asciidoctor
+- description: Git branch/tag reference
+  name: SOURCE_REPOSITORY_REF
+  value: master
+- description: Git source URL for application
+  name: SOURCE_REPOSITORY_URL
+  required: true
+  value: https://github.com/redhat-cop/containers-quickstarts
+

--- a/ubi8-asciidoctor/Dockerfile
+++ b/ubi8-asciidoctor/Dockerfile
@@ -1,0 +1,65 @@
+FROM registry.access.redhat.com/ubi8-minimal
+
+LABEL MAINTAINERS="Red Hat Services"
+
+ARG asciidoctor_version=2.0.10
+ARG asciidoctor_confluence_version=0.0.2
+ARG asciidoctor_pdf_version=1.5.3
+ARG asciidoctor_diagram_version=1.5.19
+ARG asciidoctor_epub3_version=1.5.0.alpha.12
+ARG asciidoctor_mathematical_version=0.3.1
+ARG asciidoctor_revealjs_version=2.0.0
+ARG kramdown_asciidoc_version=1.0.1
+
+
+ENV ASCIIDOCTOR_VERSION=${asciidoctor_version} \
+  ASCIIDOCTOR_CONFLUENCE_VERSION=${asciidoctor_confluence_version} \
+  ASCIIDOCTOR_PDF_VERSION=${asciidoctor_pdf_version} \
+  ASCIIDOCTOR_DIAGRAM_VERSION=${asciidoctor_diagram_version} \
+  ASCIIDOCTOR_EPUB3_VERSION=${asciidoctor_epub3_version} \
+  ASCIIDOCTOR_MATHEMATICAL_VERSION=${asciidoctor_mathematical_version} \
+  ASCIIDOCTOR_REVEALJS_VERSION=${asciidoctor_revealjs_version} \
+  KRAMDOWN_ASCIIDOC_VERSION=${kramdown_asciidoc_version}
+
+
+
+USER root
+
+RUN microdnf install tar gzip git make cmake python3 python3-setuptools ruby-devel gcc redhat-rpm-config zlib-devel patch git gcc-c++ glib2-devel
+
+# Installing Ruby Gems needed in the image
+# including asciidoctor itself
+# TODO: have to find Lasem dev libs     "asciidoctor-mathematical:${ASCIIDOCTOR_MATHEMATICAL_VERSION}" \
+RUN gem install --no-document \
+    "asciidoctor:${ASCIIDOCTOR_VERSION}" \
+    "asciidoctor-confluence:${ASCIIDOCTOR_CONFLUENCE_VERSION}" \
+    "asciidoctor-diagram:${ASCIIDOCTOR_DIAGRAM_VERSION}" \
+    "asciidoctor-epub3:${ASCIIDOCTOR_EPUB3_VERSION}" \
+    asciimath \
+    "asciidoctor-pdf:${ASCIIDOCTOR_PDF_VERSION}" \
+    "asciidoctor-revealjs:${ASCIIDOCTOR_REVEALJS_VERSION}" \
+    coderay \
+    epubcheck-ruby:4.2.2.0 \
+    haml \
+    kindlegen:3.0.5 \
+    "kramdown-asciidoc:${KRAMDOWN_ASCIIDOC_VERSION}" \
+    rouge \
+    slim \
+    thread_safe \
+    tilt
+
+# Installing Python dependencies for additional
+# functionnalities as diagrams or syntax highligthing
+RUN pip3 install \
+    actdiag \
+    'blockdiag[pdf]' \
+    nwdiag \
+    seqdiag
+
+WORKDIR /documents
+VOLUME /documents
+
+USER 1001
+
+CMD ["/bin/bash"]
+

--- a/ubi8-asciidoctor/README.md
+++ b/ubi8-asciidoctor/README.md
@@ -1,0 +1,8 @@
+# ubi8-asciidoctor
+
+A utility image that is the UBI8 image + asciidoctor. 
+
+It's base is from https://github.com/asciidoctor/docker-asciidoctor but now ubi based.
+
+Useful for use in things like GitLab CI pipelines where you want to use a UBI based image and need access to asciidoctor-pdf.
+

--- a/ubi8-asciidoctor/README.md
+++ b/ubi8-asciidoctor/README.md
@@ -1,6 +1,8 @@
 # ubi8-asciidoctor
 
-A utility image that is the UBI8 image + asciidoctor. 
+A utility image for the UBI8 image + asciidoctor. 
+
+Contains the primary used asciidoctor-pdf for generating reports.
 
 It's base is from https://github.com/asciidoctor/docker-asciidoctor but now ubi based.
 


### PR DESCRIPTION
#### What is this PR About?
Contains the toolset of asciidoctor which was based on Alpine but in this container it is ubi-minimal based. We have a ubi8 based toolset to for instance generate pdf's from an asciidocotor document.

#### How do we test this?
You could build the docker image and run it if you like. We are using these images in an internal pipeline at the moment but thought it best to share them with the world.

```
podman run --rm --name asciidoctor  -v ./:/documents/  -w /documents/ ubi8-asciidoctor      asciidoctor-pdf -r asciidoctor-diagram -a ej-base-dir=/documents/ -a ej-projectdir=/documents/ document.adoc
```
cc: @redhat-cop/day-in-the-life
