### PR TITLE
ubi8-git and ubi8-google-api - update to use registry.access.redhat.com/ubi8

### DIFF
--- a/ubi8-git/Dockerfile
+++ b/ubi8-git/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubi8
+FROM registry.access.redhat.com/ubi8
 
 LABEL maintainer="Red Hat Services"
 

--- a/ubi8-google-api-python-client/Dockerfile
+++ b/ubi8-google-api-python-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubi8
+FROM registry.access.redhat.com/ubi8
 
 LABEL maintainer="Red Hat Services"
 


### PR DESCRIPTION
#### What is this PR About?
Fixes the source for the ubi8 image to be explicate so it can build in quay.io

#### How do we test this?
example: https://quay.io/repository/itewk/ubi8-git?tab=builds

cc: @redhat-cop/day-in-the-life
