### PR TITLE
Added Helm 3 chart for motepair

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A set of buildConfigs for building custom Jenkins images for OpenShift.
 ### Developer Tools
 
 * [Tool Box](./tool-box) - An OpenShift deployable container image that provides some necessary developer tools
+* [motepair](./motepair) - Remote pair programming server and plugin for [Atom](https://atom.io/)
 
 ## Related Content
 

--- a/motepair/.helmignore
+++ b/motepair/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/motepair/Chart.yaml
+++ b/motepair/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: motepair
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.0

--- a/motepair/README.md
+++ b/motepair/README.md
@@ -1,0 +1,18 @@
+# MOTEPAIR
+
+## Overview
+
+[MOTEPAIR](https://github.com/motepair) is a server application and a plugin for the [Atom Editor](https://atom.io/) which
+allows for an organization to host/manage their own remote pair programming solution.
+
+## Installation
+
+```
+git clone https://github.com/redhat-cop/containers-quickstarts.git
+cd containers-quickstarts/motepair
+helm install motepair ./
+```
+
+## Using MOTEPAIR with Atom
+
+[Instructions](https://github.com/motepair/motepair)

--- a/motepair/templates/NOTES.txt
+++ b/motepair/templates/NOTES.txt
@@ -1,0 +1,5 @@
+1. Get the application URL by running these commands:
+
+   oc get route motepair-server -ocustom-columns=URL:.spec.host
+
+2. Connect to motepair using the instructions: https://github.com/motepair/motepair

--- a/motepair/templates/_helpers.tpl
+++ b/motepair/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "motepair.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "motepair.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "motepair.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "motepair.labels" -}}
+helm.sh/chart: {{ include "motepair.chart" . }}
+{{ include "motepair.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "motepair.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "motepair.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "motepair.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "motepair.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/motepair/templates/buildconfig.yaml
+++ b/motepair/templates/buildconfig.yaml
@@ -1,0 +1,28 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: motepair-server
+  name: motepair-server
+spec:
+  failedBuildsHistoryLimit: 5
+  nodeSelector: {}
+  output:
+    to:
+      kind: ImageStreamTag
+      name: motepair-server:latest
+  postCommit: {}
+  resources: {}
+  runPolicy: Serial
+  source:
+    git:
+      uri: https://github.com/motepair/motepair-server.git
+    type: Git
+  strategy:
+    dockerStrategy: {}
+    type: Docker
+  successfulBuildsHistoryLimit: 5
+  triggers:
+  - type: ConfigChange
+status:
+  lastVersion: 0

--- a/motepair/templates/deploymentconfig.yaml
+++ b/motepair/templates/deploymentconfig.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: motepair-server
+  name: motepair-server
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    app: motepair-server
+  strategy:
+    activeDeadlineSeconds: 21600
+    resources: {}
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    type: Rolling
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: motepair-server
+    spec:
+      containers:
+      - image: "image-registry.openshift-image-registry.svc:5000/{{ .Release.Namespace }}/motepair-server:latest"
+        imagePullPolicy: Always
+        name: motepair-server
+        ports:
+        - containerPort: 3000
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  test: false
+  triggers:
+  - type: ConfigChange
+  - type: ImageChange
+    imageChangeParams:
+      automatic: true
+      containerNames:
+      - motepair-server
+      from:
+        kind: ImageStreamTag
+        namespace: "{{ .Release.Namespace }}"
+        name: 'motepair-server:latest'

--- a/motepair/templates/imagestream.yaml
+++ b/motepair/templates/imagestream.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: motepair-server
+spec:
+  lookupPolicy:
+    local: false

--- a/motepair/templates/route.yaml
+++ b/motepair/templates/route.yaml
@@ -1,0 +1,19 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: motepair-server
+spec:
+  host: ""
+  port:
+    targetPort: 3000
+  subdomain: ""
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: motepair-server
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress: []

--- a/motepair/templates/service.yaml
+++ b/motepair/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: motepair-server
+spec:
+  clusterIP: ""
+  ports:
+  - port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: motepair-server
+  sessionAffinity: None
+  type: ClusterIP
+status: {}

--- a/motepair/values.yaml
+++ b/motepair/values.yaml
@@ -1,0 +1,3 @@
+# Default values for motepair.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.


### PR DESCRIPTION
#### What is this PR About?
Add Helm 3 chart for build/deploy of [motepair](https://github.com/motepair/motepair-server)

Resolves #315

#### How do we test this?
```
git clone git@github.com:redhat-cop/containers-quickstarts.git
cd containers-quicktstarts/motepair
git checkout Issue-315-_-Add_motepair_build_deploy_ability
helm install motepair ./
```

cc: @redhat-cop/day-in-the-life
