### PR TITLE
Add CI tests for gradle, mongodb, npm & python jenkins agents

### DIFF
--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -14,12 +14,12 @@ jenkins_slaves:
       SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
       SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     arachni: {}
+    argocd: {}
     erlang: {}
     golang: {}
     gradle: {}
-    mongodb: {}
-    argocd: {}
     helm: {}
+    mongodb: {}
     mvn:
       BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-maven:4.2
     npm:
@@ -43,9 +43,21 @@ test_pipelines:
       PIPELINE_FILENAME: Jenkinsfile.test
       PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
+    argocd:
+      NAME: jenkins-slave-argocd
+      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-argocd
+      PIPELINE_FILENAME: Jenkinsfile.test
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     erlang:
       NAME: jenkins-slave-erlang
       PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-erlang
+      PIPELINE_FILENAME: Jenkinsfile.test
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
+    helm:
+      NAME: jenkins-slave-helm
+      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-helm
       PIPELINE_FILENAME: Jenkinsfile.test
       PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
@@ -55,27 +67,39 @@ test_pipelines:
       PIPELINE_FILENAME: Jenkinsfile.test
       PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
+    gradle:
+      NAME: jenkins-slave-gradle
+      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-gradle
+      PIPELINE_FILENAME: Jenkinsfile.test
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
+    mongodb:
+      NAME: jenkins-slave-mongodb
+      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-mongodb
+      PIPELINE_FILENAME: Jenkinsfile.test
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     mvn:
       NAME: jenkins-slave-mvn
       PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-mvn
       PIPELINE_FILENAME: Jenkinsfile.test
       PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
+    npm:
+      NAME: jenkins-slave-npm
+      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-npm
+      PIPELINE_FILENAME: Jenkinsfile.test
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
+    python:
+      NAME: jenkins-slave-python
+      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-python
+      PIPELINE_FILENAME: Jenkinsfile.test
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     ruby:
       NAME: jenkins-slave-ruby
       PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-ruby
-      PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
-      PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
-    argocd:
-      NAME: jenkins-slave-argocd
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-argocd
-      PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
-      PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
-    helm:
-      NAME: jenkins-slave-helm
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-helm
       PIPELINE_FILENAME: Jenkinsfile.test
       PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"

--- a/jenkins-slaves/jenkins-slave-gradle/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-gradle/Dockerfile
@@ -1,6 +1,9 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.2
+FROM quay.io/openshift/origin-jenkins-agent-base:4.3
 
-ENV GRADLE_VERSION=4.8
+ENV GRADLE_VERSION=6.3
+ENV GRADLE_USER_HOME=/home/jenkins/.gradle
+
+ADD ubi.repo /etc/yum.repos.d/ubi.repo
 
 RUN curl -skL -o /tmp/gradle-bin.zip https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip && \
     mkdir -p /opt/gradle && \
@@ -8,6 +11,9 @@ RUN curl -skL -o /tmp/gradle-bin.zip https://services.gradle.org/distributions/g
     ln -sf /opt/gradle/gradle-$GRADLE_VERSION/bin/gradle /usr/local/bin/gradle && \
     rm -f /tmp/gradle-bin.zip && \
     chown -R 1001:0 /opt/gradle && \
-    chmod -R g+rw /opt/gradle
+    chmod -R g+rw /opt/gradle && \
+    mkdir /home/jenkins/.gradle && \
+    chmod 775 /home/jenkins/.gradle && \
+    alternatives --auto java
 
 USER 1001

--- a/jenkins-slaves/jenkins-slave-gradle/Jenkinsfile.test
+++ b/jenkins-slaves/jenkins-slave-gradle/Jenkinsfile.test
@@ -1,0 +1,18 @@
+pipeline {
+    agent {
+      label 'jenkins-slave-gradle'
+    }
+
+    stages {
+        stage ('Run Test') {
+            steps {
+              sh """
+                  java -version
+                  gradle --version
+              """
+            }
+        }
+
+    }
+
+}

--- a/jenkins-slaves/jenkins-slave-gradle/ubi.repo
+++ b/jenkins-slaves/jenkins-slave-gradle/ubi.repo
@@ -1,0 +1,104 @@
+[ubi-7]
+name = Red Hat Universal Base Image 7 Server (RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-debug-rpms]
+name = Red Hat Universal Base Image 7 Server (Debug RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-source-rpms]
+name = Red Hat Universal Base Image 7 Server (Source RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-optional-rpms]
+name = Red Hat Universal Base Image 7 Server - Optional (RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/optional/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-optional-debug-rpms]
+name = Red Hat Universal Base Image 7 Server - Optional (Debug RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/optional/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-optional-source-rpms]
+name = Red Hat Universal Base Image 7 Server - Optional (Source RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/optional/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-extras-rpms]
+name = Red Hat Universal Base Image 7 Server - Extras (RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/extras/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-extras-debug-rpms]
+name = Red Hat Universal Base Image 7 Server - Extras (Debug RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/extras/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-extras-source-rpms]
+name = Red Hat Universal Base Image 7 Server - Extras (Source RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/extras/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-rhah]
+name = Red Hat Universal Base Image Atomic Host (RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/atomic/7/7Server/$basearch/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-rhah-debug]
+name = Red Hat Universal Base Image Atomic Host (Debug RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/atomic/7/7Server/$basearch/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-rhah-source]
+name = Red Hat Universal Base Image Atomic Host (Source RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/atomic/7/7Server/$basearch/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-server-rhscl-7-rpms]
+name = Red Hat Software Collections RPMs for Red Hat Universal Base Image 7 Server
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/rhscl/1/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-server-rhscl-7-debug-rpms]
+name = Red Hat Software Collections Debug RPMs for Red Hat Universal Base Image 7 Server
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/rhscl/1/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-server-rhscl-7-source-rpms]
+name = Red Hat Software Collections Source RPMs for Red Hat Universal Base Image 7 Server
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/rhscl/1/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1

--- a/jenkins-slaves/jenkins-slave-mongodb/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-mongodb/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.2
+FROM quay.io/openshift/origin-jenkins-agent-base:4.3
 
 USER root
 

--- a/jenkins-slaves/jenkins-slave-mongodb/Jenkinsfile.test
+++ b/jenkins-slaves/jenkins-slave-mongodb/Jenkinsfile.test
@@ -1,0 +1,17 @@
+pipeline {
+    agent {
+      label 'jenkins-slave-mongodb'
+    }
+
+    stages {
+        stage ('Run Test') {
+            steps {
+              sh """
+                  mongo --version
+              """
+            }
+        }
+
+    }
+
+}

--- a/jenkins-slaves/jenkins-slave-npm/Jenkinsfile.test
+++ b/jenkins-slaves/jenkins-slave-npm/Jenkinsfile.test
@@ -1,0 +1,18 @@
+pipeline {
+    agent {
+      label 'jenkins-slave-npm'
+    }
+
+    stages {
+        stage ('Run Test') {
+            steps {
+              sh """
+                  npm -v
+                  node -v
+              """
+            }
+        }
+
+    }
+
+}

--- a/jenkins-slaves/jenkins-slave-python/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.2
+FROM quay.io/openshift/origin-jenkins-agent-base:4.3
 
 EXPOSE 8080
 

--- a/jenkins-slaves/jenkins-slave-python/Jenkinsfile.test
+++ b/jenkins-slaves/jenkins-slave-python/Jenkinsfile.test
@@ -1,0 +1,17 @@
+pipeline {
+    agent {
+      label 'jenkins-slave-python'
+    }
+
+    stages {
+        stage ('Run Test') {
+            steps {
+              sh """
+                  python -V
+              """
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
#### What is this PR About?
Add CI for gradle, mongodb, npm & python jenkins agents

#### How do we test this?
Use `./_test/setup.sh applier && ./_test/setup.sh test`

cc: @redhat-cop/day-in-the-life
