### PR TITLE
Fix broken links in Markdown documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A set of buildConfigs for building custom Jenkins images for OpenShift.
 
 ### Gitlab Runners
 
-Gitlab Runners for yoru [Gitlab CI/CD](https://docs.gitlab.com/runner/).
+Gitlab Runners for your [Gitlab CI/CD](https://docs.gitlab.com/runner/).
 
 * [UBI 7](./ubi7-gitlab-runner)
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,15 @@ A set of buildConfigs for building custom Jenkins images for OpenShift.
 
 ### Gitlab Runners
 
-A set of [Gitlab Runners](./gitlab-runners/README.md) for your [Gitlab CI/CD](https://docs.gitlab.com/runner/).
+Gitlab Runners for yoru [Gitlab CI/CD](https://docs.gitlab.com/runner/).
 
-* [UBI 7](./gitlab-runners/ubi7-gitlab-runner)
-* [UBI 8 Asciidoctor](./gitlab-runners/ubi8-asciidoctor)
-* [UBI 8 Git](./gitlab-runners/ubi8-git)
-* [UBI 8 Google API Pyton Client](./gitlab-runners/ubi8-google-api-python-client)
+* [UBI 7](./ubi7-gitlab-runner)
+
+### Utilities
+
+* [UBI 8 Asciidoctor](./utilities/ubi8-asciidoctor)
+* [UBI 8 Git](./utilities/ubi8-git)
+* [UBI 8 Google API Pyton Client](./utilities/ubi8-google-api-python-client)
 
 ### Developer Tools
 

--- a/ubi7-gitlab-runner/README.md
+++ b/ubi7-gitlab-runner/README.md
@@ -50,4 +50,4 @@ oc patch deployment/gitlab-runner-gitlab-runner --type json --patch '[{ "op": "r
 
 ## Published
 
-[https://quay.io/repository/redhat-cop/ubi7-gitlab-runner](https://quay.io/repository/redhat-cop/ubi7-gitlab-runner) via [GitHub Workflows](.github/workflows/ubi7-gitlab-runner-publish.yaml).
+[https://quay.io/repository/redhat-cop/ubi7-gitlab-runner](https://quay.io/repository/redhat-cop/ubi7-gitlab-runner) via [GitHub Workflows](../.github/workflows/ubi7-gitlab-runner-publish.yaml).

--- a/utilities/README.md
+++ b/utilities/README.md
@@ -6,4 +6,4 @@ This directory contains utility images with specific tolling in them. Useful for
 
 ## Published Images
 
-The images are also [published to Quay](https://quay.io/organization/redhat-cop) through the use of [Github Workflows](/.github/workflows).
+The images are also [published to Quay](https://quay.io/organization/redhat-cop) through the use of [Github Workflows](../.github/workflows).

--- a/utilities/ubi8-asciidoctor/README.md
+++ b/utilities/ubi8-asciidoctor/README.md
@@ -14,4 +14,4 @@ Useful for environments where these libraries/tools are needed such as:
 
 ## Published
 
-[https://quay.io/repository/redhat-cop/ubi8-asciidoctor](https://quay.io/repository/redhat-cop/ubi8-asciidoctor) via [GitHub Workflows](.github/workflows/ubi8-asciidoctor-publish.yaml).
+[https://quay.io/repository/redhat-cop/ubi8-asciidoctor](https://quay.io/repository/redhat-cop/ubi8-asciidoctor) via [GitHub Workflows](../../.github/workflows/ubi8-asciidoctor-publish.yaml).

--- a/utilities/ubi8-git/README.md
+++ b/utilities/ubi8-git/README.md
@@ -10,4 +10,4 @@ Useful for environments where these libraries/tools are needed such as:
 
 ## Published
 
-[https://quay.io/repository/redhat-cop/ubi8-git](https://quay.io/repository/redhat-cop/ubi8-git) via [GitHub Workflows](.github/workflows/ubi8-git-publish.yaml).
+[https://quay.io/repository/redhat-cop/ubi8-git](https://quay.io/repository/redhat-cop/ubi8-git) via [GitHub Workflows](../../.github/workflows/ubi8-git-publish.yaml).

--- a/utilities/ubi8-google-api-python-client/README.md
+++ b/utilities/ubi8-google-api-python-client/README.md
@@ -10,4 +10,4 @@ Useful for environments where these libraries/tools are needed such as:
 
 ## Published
 
-[https://quay.io/repository/redhat-cop/ubi8-google-api-python-client](https://quay.io/repository/redhat-cop/ubi8-google-api-python-client) via [GitHub Workflows](.github/workflows/ubi8-google-api-python-client-publish.yaml).
+[https://quay.io/repository/redhat-cop/ubi8-google-api-python-client](https://quay.io/repository/redhat-cop/ubi8-google-api-python-client) via [GitHub Workflows](../../.github/workflows/ubi8-google-api-python-client-publish.yaml).


### PR DESCRIPTION
#### What is this PR About?
This will update a few broken links in Markdown documents.
**NOTE:** There are still two broken links in [s2i-liberty/README](/redhat-cop/containers-quickstarts/blob/master/build-s2i-liberty/README.md#considerations-on-http-session-failover) that I haven't found updated pages for.

I also plan to add a CI test for this that will address #304 

#### How do we test this?
```
podman run -it --rm -v $PWD:/code:z registry.access.redhat.com/ubi8/nodejs-12 bash -c 'npm install --save-dev markdown-link-check && find /code -type f -name "*.md" -exec markdown-link-check --quiet --config /code/linkcheck-config.json {} \;'
```

cc: @redhat-cop/day-in-the-life
