### PR TITLE
Fix broken s2i-liberty links

### DIFF
--- a/build-s2i-liberty/README.md
+++ b/build-s2i-liberty/README.md
@@ -92,11 +92,11 @@ You can set the following environment variable on containers running on images c
 
 ## Considerations on http session failover
 
-When liberty is deployed in a cloud environment, there are certain limitations that apply as explained in this [document](http://www.ibm.com/support/knowledgecenter/en/SSD28V_8.5.5/com.ibm.websphere.wlp.core.doc/ae/cwlp_paas_restrict.html).
+When liberty is deployed in a cloud environment, there are certain limitations that apply as explained in this [document](https://www.ibm.com/support/knowledgecenter/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/cwlp_paas_restrict.html).
 With respect to the http session failover, two techniques generally apply:
 
 1. session replication: Liberty does not support session replication out-of-the-box. This feature can be implemented by integrating with eXtremeScale, as described in this [article](http://www.ibm.com/support/knowledgecenter/SSTVLU_8.6.0/com.ibm.websphere.extremescale.doc/cxshttpsession.html?view=embed).  
-2. session persistence: it is possible to persist the session using any database that support a JDBC connection. This [article](http://www.ibm.com/support/knowledgecenter/en/SSD28V_8.5.5/com.ibm.websphere.base.doc/ae/tprs_cnfp.html) explains how to configure Liberty to do so.
+2. session persistence: it is possible to persist the session using any database that support a JDBC connection. This [article](https://www.ibm.com/support/knowledgecenter/SS7K4U_9.0.5/com.ibm.websphere.zseries.doc/ae/tprs_cnfp.html) explains how to configure Liberty to do so.
 
 ## Cleaning up
 ```


### PR DESCRIPTION
#### What is this PR About?
Fix two broken links in [build-s2i-liberty/README.md](/redhat-cop/containers-quickstarts/blob/master/build-s2i-liberty/README.md#considerations-on-http-session-failover).

#### How do we test this?
```
podman run -it --rm -v $PWD:/code:z registry.access.redhat.com/ubi8/nodejs-12 bash -c 'npm install --save-dev markdown-link-check && find /code -type f -name "*.md" -exec markdown-link-check --quiet --config /code/linkcheck-config.json {} \;'
```

cc: @redhat-cop/day-in-the-life
