### PR TITLE
Updated apiVersions to fully qualified 4.x compatible for SecurityContextConstraints

### DIFF
--- a/gitlab-ce/.openshift/templates/gitlab-ssl.yml
+++ b/gitlab-ce/.openshift/templates/gitlab-ssl.yml
@@ -13,8 +13,8 @@ metadata:
 labels:
   createdBy: gitlab-ce-template
 objects:
-- kind: SecurityContextConstraints
-  apiVersion: security.openshift.io/v1
+- apiVersion: security.openshift.io/v1
+  kind: SecurityContextConstraints
   allowHostDirVolumePlugin: false
   allowHostIPC: false
   allowHostNetwork: false

--- a/gogs/.openshift/templates/gogs-persistent-template.yaml
+++ b/gogs/.openshift/templates/gogs-persistent-template.yaml
@@ -6,8 +6,8 @@ metadata:
     tags: instant-app,gogs,go,golang
   name: gogs
 objects:
-- kind: SecurityContextConstraints
-  apiVersion: v1
+- apiVersion: security.openshift.io/v1
+  kind: SecurityContextConstraints
   allowHostDirVolumePlugin: false
   allowHostIPC: false
   allowHostNetwork: false

--- a/mongodb/.openshift/templates/configsvr.yml
+++ b/mongodb/.openshift/templates/configsvr.yml
@@ -77,8 +77,8 @@ objects:
       selector:
         name: "${APP_NAME}configsvr"
 
-  - kind: StatefulSet
-    apiVersion: apps/v1beta1
+  - apiVersion: apps/v1
+    kind: StatefulSet
     metadata:
       name: "${APP_NAME}configsvr"
       labels:

--- a/mongodb/.openshift/templates/replset.yml
+++ b/mongodb/.openshift/templates/replset.yml
@@ -104,8 +104,8 @@ objects:
       selector:
         name: "${APP_NAME}replset${REPLSET_SEED}"
 
-  - kind: StatefulSet
-    apiVersion: apps/v1beta1
+  - apiVersion: apps/v1
+    kind: StatefulSet
     metadata:
       app: "${APP_NAME}"
       name: "${APP_NAME}replset${REPLSET_SEED}"

--- a/rabbitmq/.openshift/templates/deployments/template.yml
+++ b/rabbitmq/.openshift/templates/deployments/template.yml
@@ -43,7 +43,7 @@ objects:
       application: "${APPLICATION_NAME}"
     sessionAffinity: None
     type: ClusterIP
-- apiVersion: apps/v1beta1
+- apiVersion: apps/v1
   kind: StatefulSet
   metadata:
     labels:


### PR DESCRIPTION
#### What is this PR About?
As per other PRs related to apiVersions. Moves SCCs to be v4

cc: @redhat-cop/day-in-the-life
