### PR TITLE
Update Jenkins Image Mgmt to use UBI & latest skopeo

### DIFF
--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -74,6 +74,12 @@ test_pipelines:
       PIPELINE_FILENAME: Jenkinsfile.test
       PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
+    image-mgmt:
+      NAME: jenkins-slave-image-mgmt
+      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-image-mgmt
+      PIPELINE_FILENAME: Jenkinsfile.test
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     mongodb:
       NAME: jenkins-slave-mongodb
       PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-mongodb
@@ -135,6 +141,11 @@ openshift_cluster_content:
   - name: jenkins-slaves
     template: "{{ inventory_dir }}/../.openshift/templates/jenkins-slave-generic-template.j2"
     params_from_vars: "{{ jenkins_slaves.build }}"
+    namespace: "{{ namespace }}"
+    tags:
+      - jenkins-slaves
+  - name: jenkins-slave-image-mgmt
+    template: "{{ inventory_dir }}/../.openshift/templates/jenkins-slave-image-mgmt-template.yml"
     namespace: "{{ namespace }}"
     tags:
       - jenkins-slaves

--- a/.openshift/templates/jenkins-slave-image-mgmt-template.yml
+++ b/.openshift/templates/jenkins-slave-image-mgmt-template.yml
@@ -12,15 +12,22 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
-    name: jenkins-slave-base-rhel7
+    name: jenkins-builder-image
   spec:
-    dockerImageRepository: registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7
+    dockerImageRepository: ${BUILDER_IMAGE_URI}
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    labels:
+      build: "${JENKINS_SLAVE_NAME}-skopeo"
+    name: "${JENKINS_SLAVE_NAME}-skopeo"
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     annotations:
       slave-label: ${JENKINS_SLAVE_NAME}
     labels:
+      build: ${JENKINS_SLAVE_NAME}
       role: jenkins-slave
     name: ${JENKINS_SLAVE_NAME}
 - apiVersion: build.openshift.io/v1
@@ -28,48 +35,93 @@ objects:
   metadata:
     labels:
       build: ${JENKINS_SLAVE_NAME}
+    name: "${JENKINS_SLAVE_NAME}-skopeo"
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: "${JENKINS_SLAVE_NAME}-skopeo:${SLAVE_IMAGE_TAG}"
+    source:
+      git:
+        uri: ${SOURCE_REPOSITORY_URL}
+        ref: ${SOURCE_REPOSITORY_REF}
+      dockerfile: |
+        FROM ""
+        USER root
+        RUN mkdir -p /tmp/skopeo
+        COPY . /tmp/skopeo
+        RUN cd /tmp/skopeo && \
+            make binary-local DISABLE_CGO=1
+      type: Source
+    strategy:
+      dockerStrategy:
+        from:
+          kind: DockerImage
+          name: "${SKOPEO_BUILDER_IMAGE_URI}:${SKOPEO_BUILDER_IMAGE_TAG}"
+          imagePullPolicy: Always
+      type: Docker
+    triggers:
+    - type: ConfigChange
+- apiVersion: build.openshift.io/v1
+  kind: BuildConfig
+  metadata:
     name: ${JENKINS_SLAVE_NAME}
   spec:
     output:
       to:
         kind: ImageStreamTag
-        name: ${JENKINS_SLAVE_NAME}:v3.11
-    postCommit: {}
-    resources: {}
-    runPolicy: Serial
+        name: "${JENKINS_SLAVE_NAME}:${SLAVE_IMAGE_TAG}"
     source:
-      contextDir: ${CONTEXT_DIR}
-      git:
-        ref: ${SOURCE_REPOSITORY_REF}
-        uri: ${SOURCE_REPOSITORY_URL}
-      type: Git
+      dockerfile: |
+        FROM ""
+        USER root
+        RUN mkdir -p /etc/containers
+        COPY default-policy.json /etc/containers/policy.json
+        COPY skopeo /usr/bin/skopeo
+        USER 1001
+      images:
+      - as: null
+        from:
+          kind: ImageStreamTag
+          name: "${JENKINS_SLAVE_NAME}-skopeo:latest"
+        paths:
+        - destinationDir: "."
+          sourcePath: /tmp/skopeo/default-policy.json
+        - destinationDir: "."
+          sourcePath: /tmp/skopeo/skopeo
+      type: Dockerfile
     strategy:
       dockerStrategy:
         from:
           kind: ImageStreamTag
-          name: jenkins-slave-base-rhel7:v3.11
+          name: jenkins-builder-image:latest
       type: Docker
     triggers:
     - imageChange: {}
       type: ImageChange
 parameters:
+- description: Image registry from which to build this image
+  name: BUILDER_IMAGE_URI
+  value: quay.io/openshift/origin-jenkins-agent-base
+- description: Image tag from which to build this image
+  name: BUILDER_IMAGE_TAG
+  value: "4.4"
 - description: The name for the Jenkins slave.
   name: JENKINS_SLAVE_NAME
   required: true
   value: jenkins-slave-image-mgmt
+- description: Skopeo builder image
+  name: SKOPEO_BUILDER_IMAGE_URI
+  value: registry.access.redhat.com/ubi8/go-toolset
+- description: Skopeo builder image tag
+  name: SKOPEO_BUILDER_IMAGE_TAG
+  value: latest
+- description: This is the image tag used for the Jenkins slave.
+  name: SLAVE_IMAGE_TAG
+  value: latest
 - description: Git source URI for application
   name: SOURCE_REPOSITORY_URL
-  required: true
-  value: https://github.com/redhat-cop/containers-quickstarts.git
+  value: https://github.com/containers/skopeo.git
 - description: Git branch/tag reference
   name: SOURCE_REPOSITORY_REF
-  required: false
-  value: master
-- description: Path within Git project to build; empty for root project directory.
-  name: CONTEXT_DIR
-  required: false
-  value: jenkins-slaves/jenkins-slave-image-mgmt
-- description: The RHEL releasever
-  name: RHEL_RELEASEVER
-  required: true
-  value: 7Server
+  value: v1.0.0

--- a/_test/setup.sh
+++ b/_test/setup.sh
@@ -5,6 +5,7 @@ NAMESPACE="${2:-containers-quickstarts-tests}"
 TRAVIS_REPO_SLUG="${3:-redhat-cop/containers-quickstarts}"
 TRAVIS_BRANCH="${4:-master}"
 
+CHAINED_BUILDS=("jenkins-slave-image-mgmt")
 TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 . ${TEST_DIR}/common.sh
 
@@ -49,7 +50,7 @@ test() {
   for buildConfig in $(oc get buildconfig -n ${NAMESPACE} -o jsonpath="{.items[?(@.spec.strategy.type==\"${build_type}\")].metadata.name}"); do
     # Only start BuildConfigs which currently have 0 builds
     if [ "$(oc get build -n ${NAMESPACE} -o jsonpath="{.items[?(@.metadata.annotations.openshift\.io/build-config\.name==\"${buildConfig}\")].metadata.name}")" == "" ]; then
-      oc start-build ${buildConfig} -n ${NAMESPACE}
+      [[ ! "${CHAINED_BUILDS[@]}" =~ "${buildConfig}" ]] && oc start-build ${buildConfig} -n ${NAMESPACE}
     fi
   done
 

--- a/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/Dockerfile
@@ -1,4 +1,15 @@
-FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11
+FROM registry.access.redhat.com/ubi8/go-toolset:latest as builder
+
+ARG SKOPEO_VERSION=1.0.0
+
+USER root
+
+RUN curl -L https://github.com/containers/skopeo/archive/v${SKOPEO_VERSION}.tar.gz | tar -C /tmp -zxf - && \
+    mv /tmp/skopeo-${SKOPEO_VERSION} /tmp/skopeo && \
+    cd /tmp/skopeo && \
+    make binary-local DISABLE_CGO=1
+
+FROM quay.io/openshift/origin-jenkins-agent-base:4.4
 
 MAINTAINER Andrew Block <ablock@redhat.com>
 
@@ -8,16 +19,12 @@ LABEL com.redhat.component="jenkins-slave-image-mgmt" \
       io.k8s.display-name="Jenkins Slave Image Management" \
       io.k8s.description="Image management tools on top of the jenkins slave base image" \
       io.openshift.tags="openshift,jenkins,slave,copy"
+
 USER root
 
-RUN INSTALL_PKGS="skopeo" && \
-    if [ -z $RHEL_RELEASEVER ] ; then RHEL_RELEASEVER=7Server ; fi && \
-    yum install -y --setopt=tsflags=nodocs \
-      --enablerepo=rhel-7-server-rpms \
-      --enablerepo=rhel-7-server-extras-rpms \
-      --releasever=${RHEL_RELEASEVER} \
-      $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    yum clean all
+RUN mkdir -p /etc/containers
+
+COPY --from=builder /tmp/skopeo/default-policy.json /etc/containers/policy.json
+COPY --from=builder /tmp/skopeo/skopeo /usr/bin/
 
 USER 1001

--- a/jenkins-slaves/jenkins-slave-image-mgmt/Jenkinsfile.test
+++ b/jenkins-slaves/jenkins-slave-image-mgmt/Jenkinsfile.test
@@ -1,0 +1,15 @@
+pipeline {
+    agent {
+        label 'jenkins-slave-image-mgmt'
+    }
+
+    stages {
+        stage ('Run Test') {
+            steps {
+                sh """
+                    skopeo inspect docker://quay.io/openshift/origin-jenkins-agent-base
+                """
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### What is this PR About?
Update `jenkins-slave-image-mgmt` to use UBI base image and latest version of Skopeo.

#### How do we test this?
Wait for prow to do it for you or use instructions below.
```
oc new-project test-skopeo
./_test/setup.sh applier test-skopeo pabrahamsson/containers-quickstarts jenkins-agent-image-mgmt
./_test/setup.sh test test-skopeo pabrahamsson/containers-quickstarts jenkins-agent-image-mgmt
```
cc: @redhat-cop/day-in-the-life
