### PR TITLE
🏏 Output of failed tests swallowed. Fixing 🦇

### DIFF
--- a/_test/_helpers.bash
+++ b/_test/_helpers.bash
@@ -6,3 +6,7 @@ helm_template() {
   helm template $TEMPLATE_OPTS $(pwd) --output-dir /tmp/$CHART_DIR > /dev/null 2>&1
   popd
 }
+
+print_err() {
+  if [ "$1" -ne 0 ]; then echo "$2" | grep "not ok"; fi
+}

--- a/_test/conftest.sh
+++ b/_test/conftest.sh
@@ -4,44 +4,44 @@ load _helpers
 
 @test ".openshift" {
   run conftest test .openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "build-docker-generic/.openshift" {
   run conftest test build-docker-generic/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 
 @test "build-s2i-executable/.openshift" {
   run conftest test build-s2i-executable/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "build-s2i-gows/.openshift" {
   run conftest test build-s2i-gows/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "build-s2i-jekyll/.openshift" {
   run conftest test build-s2i-jekyll/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "build-s2i-liberty/.openshift" {
   run conftest test build-s2i-liberty/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "build-s2i-play/.openshift" {
   run conftest test build-s2i-play/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
@@ -49,49 +49,49 @@ load _helpers
   helm_template "eap/chart" "--set sourceUri=conftest"
 
   run conftest test /tmp/eap/chart/eap72/templates --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "gitlab-ce/.openshift" {
   run conftest test gitlab-ce/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "gogs/.openshift" {
   run conftest test gogs/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "hoverfly/.openshift" {
   run conftest test hoverfly/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "hygieia/.openshift" {
   run conftest test hygieia/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "ipa-server/.openshift" {
   run conftest test ipa-server/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "jenkins-masters/hygieia-plugin/.openshift" {
   run conftest test jenkins-masters/hygieia-plugin/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "mongodb/.openshift" {
   run conftest test mongodb/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
@@ -99,7 +99,7 @@ load _helpers
   helm_template "motepair"
 
   run conftest test /tmp/motepair/motepair/templates --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
@@ -107,19 +107,19 @@ load _helpers
   helm_template "nexus/chart/nexus" "--dependency-update"
 
   run conftest test /tmp/nexus/chart/nexus/nexus/charts/sonatype-nexus --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "ocp4-logging/.openshift" {
   run conftest test ocp4-logging/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "rabbitmq/.openshift" {
   run conftest test rabbitmq/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
@@ -127,42 +127,42 @@ load _helpers
   helm_template "rabbitmq/chart"
 
   run conftest test /tmp/rabbitmq/chart/RabbitMQ/templates --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "sonarqube/.openshift" {
   run conftest test sonarqube/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "ubi7-gitlab-runner/.openshift" {
   run conftest test ubi7-gitlab-runner/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "utilities/ubi8-asciidoctor/.openshift" {
   run conftest test utilities/ubi8-asciidoctor/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "utilities/ubi8-git/.openshift" {
   run conftest test utilities/ubi8-git/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "utilities/ubi8-google-api-python-client/.openshift" {
   run conftest test utilities/ubi8-google-api-python-client/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "zalenium/.openshift" {
   run conftest test zalenium/.openshift --output tap
-
+  print_err "$status" "$output"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
#### What is this PR About?
The output of the conf tests gives no indication as to what is failing thus increasing the feedback loop for debugging. I've written a simple bit of bash to capture the needed output. As per the example below:

![image](https://user-images.githubusercontent.com/6122439/83865975-fc2ebb80-a71e-11ea-907a-c1925111059f.png)

#### How do we test this?
Make one of the templates not valid, eg change a `apiVersion: template.openshift.io/v1` to just `v1`. Run the conf tests. See the error. 🧙‍♂️

cc: @redhat-cop/day-in-the-life
