### PR TITLE
Set KOPF_NAMESPACE when KOPF_NAMESPACED is set

### DIFF
--- a/build-s2i-python-kopf/s2i/run
+++ b/build-s2i-python-kopf/s2i/run
@@ -25,6 +25,7 @@ fi
 if [[ "${KOPF_NAMESPACE}" ]]; then
     KOPF_OPTIONS="${KOPF_OPTIONS} --namespace=${KOPF_NAMESPACE}"
 elif [[ "${KOPF_NAMESPACED:-false}" == "true" ]]; then
+    KOPF_NAMESPACE=${OPERATOR_NAMESPACE}
     KOPF_OPTIONS="${KOPF_OPTIONS} --namespace=${OPERATOR_NAMESPACE}"
 fi
 


### PR DESCRIPTION
#### What is this PR About?

The `KOPF_NAMESPACED` flag currently does not behave as expected when combined with `KOPF_PEERING` resulting in namespaced deployments attempting to create `ClusterKopfPeering` resources rather than the namespaced `KopfPeering`.

This fixes the issue by setting `KOPF_NAMESPACE` when `KOPF_NAMESPACED` is specified.

#### How do we test this?

Test instructions in provided examples and documentation.

cc: @redhat-cop/day-in-the-life
