### PR TITLE
increasing go version in jenkins-slave-golang to 1.14.4 and adding tests

### DIFF
--- a/jenkins-slaves/jenkins-slave-golang/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-golang/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/openshift/origin-jenkins-agent-base:4.4
 
-ENV GO_VERSION_DEFAULT=1.10.2 \
+ENV GO_VERSION_DEFAULT=1.14.4 \
     GOROOT=/usr/local/go \
     GOPATH=/usr/src/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
@@ -16,10 +16,9 @@ RUN if [ -z $GO_VERSION ] ; then GO_VERSION=${GO_VERSION_DEFAULT} ; fi && \
     mkdir -p /usr/src/go/src/redhat && \
     tar -xzf /usr/go${GO_VERSION}.linux-amd64.tar.gz && \
     mv $(pwd)/go /usr/local/ && \
-    go get -u github.com/golang/dep/cmd/dep && \
     chown -R 1001 /usr/src/go && \
     chown -R 1001 /usr/local/go && \
-    chown -R 1001 ${HOME}/.cache/go-build && \
+    chmod g+w /usr/src/go && \
     rm -f /usr/go${GO_VERSION}.linux-amd64.tar.gz
 
 USER 1001

--- a/jenkins-slaves/jenkins-slave-golang/Jenkinsfile.test
+++ b/jenkins-slaves/jenkins-slave-golang/Jenkinsfile.test
@@ -11,7 +11,24 @@ pipeline {
               """
             }
         }
-
+        stage ('Build Application') {
+          steps {
+            dir('jenkins-slaves/jenkins-slave-golang') {
+              sh """
+                  go build
+              """
+            }
+          }
+        }
+        stage ('Ensure Build was Successful') {
+          steps {
+            dir('jenkins-slaves/jenkins-slave-golang') {
+              sh """
+                  ./hello
+              """
+            }
+          }
+        }
     }
 
 }

--- a/jenkins-slaves/jenkins-slave-golang/README.md
+++ b/jenkins-slaves/jenkins-slave-golang/README.md
@@ -17,4 +17,7 @@ oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
 For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.
 
 ## Jenkins
-Add a new Kubernetes Container template called `jenkins-slave-golang` (if you've build and pushed the container image locally) and specify this as the node when running builds. If you're using the template attached; the `role: jenkins-slave` is attached and Jenkins should automatically discover the slave for you. Further instructions can be found [here](https://docs.openshift.com/container-platform/3.7/using_images/other_images/jenkins.html#using-the-jenkins-kubernetes-plug-in-to-run-jobs).
+Add a new Kubernetes Container template called `jenkins-slave-golang` (if you've build and pushed the container image locally) and specify this as the node when running builds. If you're using the template attached; the `role: jenkins-slave` is attached and Jenkins should automatically discover the slave for you. Further instructions can be found [here](https://docs.openshift.com/container-platform/4.4/openshift_images/using_images/images-other-jenkins.html#images-other-jenkins-config-kubernetes_images-other-jenkins).
+
+## Modules
+Given that Golang has decided to move towards modules for dependency management, [dep](https://github.com/golang/dep) has been removed in favor of native module functionality, available since Go v1.11. Visit the [Go blog](https://blog.golang.org/using-go-modules) to learn how you can get started with modules.

--- a/jenkins-slaves/jenkins-slave-golang/README.md
+++ b/jenkins-slaves/jenkins-slave-golang/README.md
@@ -17,11 +17,4 @@ oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
 For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.
 
 ## Jenkins
-Add a new Kubernetes Container template called `jenkins-slave-golang` (if you've build and pushed the container image locally) and specify this as the node when running builds. If you're using the template attached; the `role: jenkins-slave` is attached and Jenkins should automatically discover the slave for you. Further instructions can be found [here](https://docs.openshift.com/container-platform/3.7/using_images/other_images/jenkins.html#using-the-jenkins-kubernetes-plug-in-to-run-jobs). There are path issues with Jenkins permissions and Go when trying to run a build so easiest way to fix this is to setup the GOLANG path to be same as the WORKSPACE
-```
-export GOPATH=${WORKSPACE}
-go get -v -t ./...
-go build -v
-# if there are Ginkgo tests then also run this!
-$GOPATH/bin/ginkgo -r --cover -keepGoing
-```
+Add a new Kubernetes Container template called `jenkins-slave-golang` (if you've build and pushed the container image locally) and specify this as the node when running builds. If you're using the template attached; the `role: jenkins-slave` is attached and Jenkins should automatically discover the slave for you. Further instructions can be found [here](https://docs.openshift.com/container-platform/3.7/using_images/other_images/jenkins.html#using-the-jenkins-kubernetes-plug-in-to-run-jobs).

--- a/jenkins-slaves/jenkins-slave-golang/go.mod
+++ b/jenkins-slaves/jenkins-slave-golang/go.mod
@@ -1,0 +1,8 @@
+module example.com/hello
+
+go 1.13
+
+require (
+	golang.org/x/text v0.3.0 // indirect
+	rsc.io/quote v1.5.2
+)

--- a/jenkins-slaves/jenkins-slave-golang/go.sum
+++ b/jenkins-slaves/jenkins-slave-golang/go.sum
@@ -1,0 +1,7 @@
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+rsc.io/quote v1.5.2 h1:w5fcysjrx7yqtD/aO+QwRjYZOKnaM9Uh2b40tElTs3Y=
+rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/jenkins-slaves/jenkins-slave-golang/main.go
+++ b/jenkins-slaves/jenkins-slave-golang/main.go
@@ -1,0 +1,40 @@
+/*
+Copyright (c) 2018 Paul Jolly <paul@myitcv.io>. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package main
+
+import (
+	"fmt"
+
+	"rsc.io/quote"
+)
+
+func main() {
+	fmt.Println(quote.Hello())
+}


### PR DESCRIPTION
#### What is this PR About?
Describe the contents of the PR

* Increased the go version of jenkins-slave-golang to `1.14.4`. Upgrading to Go >1.11 will let users leverage Go modules.

* Removed `dep` from this image since newer versions of Go rely on modules. Dep recognizes this also on [their repo](https://github.com/golang/dep#dep):

    > dep was initially developed to experiment with a new dependency management system for Go; but, as of Go 1.11, the Go project has officially adopted a different approach, based on the concept of Modules

* Added a few things to help test this and future changes. I added [this hello world app](https://github.com/go-modules-by-example/index/tree/master/001_go_modules_tour) which can be built and executed in Jenkins to ensure Go apps can be built properly. I also added to Jenkinsfile.test so that the test can be easily run.

* To allow tests to run successfully, I gave `/usr/src/go` root group-writable permission so that users don't need to make any modifications on their end to build their app. I also had to remove this line from the Dockerfile:

    > chown -R 1001 ${HOME}/.cache/go-build

    because it returned "No such file or directory".

#### How do we test this?
Provide commands/steps to test this PR.

After building jenkins-agent-golang in OCP (I tested in 4.4), run Jenkinsfile.test in a multibranch pipeline and make sure that:
* The Go version prints
* The app can be built
* The app is able to run

cc: @redhat-cop/day-in-the-life
