### PR TITLE
Update ruby jenkins agent oc client to 4.4

### DIFF
--- a/jenkins-slaves/jenkins-slave-ruby/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-ruby/Dockerfile
@@ -14,7 +14,7 @@ It is simple, straight-forward, and extensible." \
   PATH=$PATH:/home/jenkins/bin \
   PROMPT_COMMAND=". /opt/app-root/etc/scl_enable" \
   HOME=/home/jenkins \
-  ORIGIN_CLIENT=https://mirror.openshift.com/pub/openshift-v3/clients/3.11.50/linux/oc.tar.gz
+  OC_VERSION=4.4
 
 
 LABEL summary="$SUMMARY" \
@@ -39,7 +39,7 @@ RUN INSTALL_PKGS="rh-ruby$RUBY_SHORT_VERSION rh-ruby$RUBY_SHORT_VERSION-ruby-dev
 
     rm -rf /var/cache/yum
 
-RUN curl $ORIGIN_CLIENT | tar -C /usr/local/bin/ -xzf - && \
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz | tar -C /usr/local/bin -xzf - && \
     chmod +x /usr/local/bin/oc
 
 # Copy extra files to the image.


### PR DESCRIPTION
#### What is this PR About?
Updating the ruby jenkins agent oc client to 4.4.

Alternatively, we could remove the custom installation of the `oc` client altogether and depend entirely on the base image to provide it. However, it does provide a slightly older version of the client as demonstrated below.

```console
$ podman run --rm --entrypoint "/bin/bash" quay.io/openshift/origin-jenkins-agent-base:4.4 -c 'oc version'     
Client Version: v4.2.0-alpha.0-459-gd038424
```

Does anyone have any thoughts regarding this?


#### How do we test this?
Standard ruby agent tests.

cc: @redhat-cop/day-in-the-life
