### PR TITLE
adding "ct" tool to jenkins-slave-helm

### DIFF
--- a/jenkins-slaves/jenkins-slave-helm/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-helm/Dockerfile
@@ -3,7 +3,6 @@ FROM quay.io/openshift/origin-jenkins-agent-base:4.4
 ARG VERSION=3.2.0 
 ARG YQ_VERSION=3.3.0
 ARG CT_VERSION=3.0.0-rc.1
-ARG GIT_VERSION=2.24.1
 ARG OPENSHIFT_CLIENT_VERSION=4.4.13
 
 ## Required in order to avoid ct "ascii codec can't encode character" error
@@ -34,11 +33,21 @@ RUN curl -sL -o /tmp/chart-testing.tar.gz https://github.com/helm/chart-testing/
 
 ## Install python 3.6, yamale, and yamllint
 RUN INSTALL_PKGS="rh-python36 rh-python36-python-pip" && \
-    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-    yum -y clean all --enablerepo='*' && \
+    yum -y --setopt=tsflags=nodocs --disablerepo='rhel-*' install $INSTALL_PKGS && \
+    yum -y clean all && \
     source scl_source enable rh-python36 && \
     python3 -m pip install yamale==3.0.1 && \
     python3 -m pip install yamllint==1.24.1
+
+## Install git > 2.17 (ubi repos don't provide this)
+RUN yum -y remove git* && \
+    yum -y --disablerepo='rhel-*' install --setopt=tsflags=nodocs centos-release-scl && \
+    yum -y --disablerepo='rhel-*' install --setopt=tsflags=nodocs rh-git218 && \
+    yum -y clean all
+
+## Install oc and kubectl
+RUN curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_CLIENT_VERSION}/openshift-client-linux-${OPENSHIFT_CLIENT_VERSION}.tar.gz \
+    | tar zxf - -C /usr/local/bin oc kubectl    
 
 ## Persistently enable software collections
 RUN mkdir /usr/share/container-scripts
@@ -47,14 +56,5 @@ RUN chmod 555 /usr/share/container-scripts/scl_enable
 ENV BASH_ENV=/usr/share/container-scripts/scl_enable \
     ENV=/usr/share/container-scripts/scl_enable \
     PROMPT_COMMAND=". /usr/share/container-scripts/scl_enable"
-
-## Install git > 2.17 (ubi repos don't provide this)
-RUN yum -y remove git* && \
-    yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.8-1.x86_64.rpm && \
-    yum -y --setopt=tsflags=nodocs install git-${GIT_VERSION}
-
-## Install oc and kubectl
-RUN curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_CLIENT_VERSION}/openshift-client-linux-${OPENSHIFT_CLIENT_VERSION}.tar.gz \
-    | tar zxf - -C /usr/local/bin oc kubectl 
 
 USER 1001

--- a/jenkins-slaves/jenkins-slave-helm/Dockerfile
+++ b/jenkins-slaves/jenkins-slave-helm/Dockerfile
@@ -2,7 +2,16 @@ FROM quay.io/openshift/origin-jenkins-agent-base:4.4
 
 ARG VERSION=3.2.0 
 ARG YQ_VERSION=3.3.0
+ARG CT_VERSION=3.0.0-rc.1
+ARG GIT_VERSION=2.24.1
+ARG OPENSHIFT_CLIENT_VERSION=4.4.13
 
+## Required in order to avoid ct "ascii codec can't encode character" error
+ENV PYTHONIOENCODING=utf-8
+
+COPY ubi.repo /etc/yum.repos.d/
+
+## Install helm and yq
 RUN curl -skL -o /tmp/helm.tar.gz https://get.helm.sh/helm-v${VERSION}-linux-amd64.tar.gz && \ 
     tar -C /tmp -xzf /tmp/helm.tar.gz && \
     mv /tmp/linux-amd64/helm /usr/local/bin && \
@@ -11,5 +20,41 @@ RUN curl -skL -o /tmp/helm.tar.gz https://get.helm.sh/helm-v${VERSION}-linux-amd
     rm -rf /tmp/linux-amd64 && \
     curl -sL  https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -o /usr/local/bin/yq && \
     chmod -R 775 /usr/local/bin/yq
+
+## Install ct
+RUN curl -sL -o /tmp/chart-testing.tar.gz https://github.com/helm/chart-testing/releases/download/v${CT_VERSION}/chart-testing_${CT_VERSION}_linux_amd64.tar.gz && \
+    mkdir /tmp/chart-testing && \
+    tar -C /tmp/chart-testing -zxf /tmp/chart-testing.tar.gz && \
+    mv /tmp/chart-testing/ct /usr/local/bin && \
+    chmod 775 /usr/local/bin/ct && \
+    rm /tmp/chart-testing.tar.gz && \
+    mkdir ${HOME}/.ct && \
+    mv /tmp/chart-testing/etc/chart_schema.yaml /tmp/chart-testing/etc/lintconf.yaml ${HOME}/.ct/ && \
+    rm -rf /tmp/chart-testing
+
+## Install python 3.6, yamale, and yamllint
+RUN INSTALL_PKGS="rh-python36 rh-python36-python-pip" && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*' && \
+    source scl_source enable rh-python36 && \
+    python3 -m pip install yamale==3.0.1 && \
+    python3 -m pip install yamllint==1.24.1
+
+## Persistently enable software collections
+RUN mkdir /usr/share/container-scripts
+COPY scl_enable /usr/share/container-scripts
+RUN chmod 555 /usr/share/container-scripts/scl_enable
+ENV BASH_ENV=/usr/share/container-scripts/scl_enable \
+    ENV=/usr/share/container-scripts/scl_enable \
+    PROMPT_COMMAND=". /usr/share/container-scripts/scl_enable"
+
+## Install git > 2.17 (ubi repos don't provide this)
+RUN yum -y remove git* && \
+    yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.8-1.x86_64.rpm && \
+    yum -y --setopt=tsflags=nodocs install git-${GIT_VERSION}
+
+## Install oc and kubectl
+RUN curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_CLIENT_VERSION}/openshift-client-linux-${OPENSHIFT_CLIENT_VERSION}.tar.gz \
+    | tar zxf - -C /usr/local/bin oc kubectl 
 
 USER 1001

--- a/jenkins-slaves/jenkins-slave-helm/Jenkinsfile.test
+++ b/jenkins-slaves/jenkins-slave-helm/Jenkinsfile.test
@@ -8,6 +8,12 @@ pipeline {
             steps {
               sh """
                   helm help
+                  ct version
+                  ls -l ${HOME}/.ct
+                  git version
+                  python --version
+                  oc version
+                  kubectl version
               """
             }
         }

--- a/jenkins-slaves/jenkins-slave-helm/README.md
+++ b/jenkins-slaves/jenkins-slave-helm/README.md
@@ -11,3 +11,13 @@ oc process -f ../../.openshift/templates/jenkins-slave-generic-template.yml \
     | oc create -n openshift -f -
 ```
 For all params see the list in the `../../.openshift/templates/jenkins-slave-generic-template.yml` or run `oc process --parameters -f ../../.openshift/templates/jenkins-slave-generic-template.yml`.
+
+## Note about ct
+`ct` (aka `Chart Testing`) is a tool for testing Helm charts in a monorepo. More information about this tool can be found at the project's [GitHub page](https://github.com/helm/chart-testing).
+
+When using `ct`, you may encounter the following error in a multibranch pipeline job:
+```
+Error linting charts: Error identifying charts to process: Error running process: exit status 128
+```
+
+Follow [this GitHub issue](https://github.com/helm/chart-testing/issues/186#issuecomment-615995590) if you run into this error. This is caused by shallow cloning, which should be disabled to fix this error.

--- a/jenkins-slaves/jenkins-slave-helm/scl_enable
+++ b/jenkins-slaves/jenkins-slave-helm/scl_enable
@@ -1,2 +1,2 @@
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-python36
+source scl_source enable rh-python36 rh-git218

--- a/jenkins-slaves/jenkins-slave-helm/scl_enable
+++ b/jenkins-slaves/jenkins-slave-helm/scl_enable
@@ -1,0 +1,2 @@
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable rh-python36

--- a/jenkins-slaves/jenkins-slave-helm/ubi.repo
+++ b/jenkins-slaves/jenkins-slave-helm/ubi.repo
@@ -1,0 +1,110 @@
+[ubi-7]
+name = Red Hat Universal Base Image 7 Server (RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-debug-rpms]
+name = Red Hat Universal Base Image 7 Server (Debug RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-source-rpms]
+name = Red Hat Universal Base Image 7 Server (Source RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-optional-rpms]
+name = Red Hat Universal Base Image 7 Server - Optional (RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/optional/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-optional-debug-rpms]
+name = Red Hat Universal Base Image 7 Server - Optional (Debug RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/optional/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-optional-source-rpms]
+name = Red Hat Universal Base Image 7 Server - Optional (Source RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/optional/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-extras-rpms]
+name = Red Hat Universal Base Image 7 Server - Extras (RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/extras/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-extras-debug-rpms]
+name = Red Hat Universal Base Image 7 Server - Extras (Debug RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/extras/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-server-extras-source-rpms]
+name = Red Hat Universal Base Image 7 Server - Extras (Source RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/extras/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-rhah]
+name = Red Hat Universal Base Image Atomic Host (RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/atomic/7/7Server/$basearch/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-rhah-debug]
+name = Red Hat Universal Base Image Atomic Host (Debug RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/atomic/7/7Server/$basearch/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-7-rhah-source]
+name = Red Hat Universal Base Image Atomic Host (Source RPMs)
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/atomic/7/7Server/$basearch/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-server-rhscl-7-rpms]
+name = Red Hat Software Collections RPMs for Red Hat Universal Base Image 7 Server
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/rhscl/1/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-server-rhscl-7-debug-rpms]
+name = Red Hat Software Collections Debug RPMs for Red Hat Universal Base Image 7 Server
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/rhscl/1/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-server-rhscl-7-source-rpms]
+name = Red Hat Software Collections Source RPMs for Red Hat Universal Base Image 7 Server
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/rhscl/1/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[centos-mirror]
+name = CentOS Mirror
+baseurl = http://mirror.centos.org/centos/7/os/x86_64/
+enabled = 1
+gpgcheck = 0

--- a/jenkins-slaves/jenkins-slave-helm/ubi.repo
+++ b/jenkins-slaves/jenkins-slave-helm/ubi.repo
@@ -108,3 +108,9 @@ name = CentOS Mirror
 baseurl = http://mirror.centos.org/centos/7/os/x86_64/
 enabled = 1
 gpgcheck = 0
+
+[centos-extras]
+name = CentOS Extras
+baseurl = http://mirror.centos.org/centos/7/extras/x86_64/
+enabled = 1
+gpgcheck = 0


### PR DESCRIPTION
#### What is this PR About?
Adds [ct](https://github.com/helm/chart-testing) to jenkins-slave-helm. Closes #387 
#### How do we test this?
Run the Jenkinsfile.test pipeline to make sure ct and each of ct's dependencies are installed.

I also have a pipeline at https://github.com/deweya/-Learn-Helm/blob/feat/ct-test/helm-charts/Jenkinsfile that can be used to test ct functionality. I have the namespace hardcoded in it, so it'd probably be best to make a fork so that you can change the namespace. If you want to use this pipeline to test, be sure to import it as a multibranch pipeline job and set the Jenkinsfile path to `helm-charts/Jenkinsfile`.

cc: @redhat-cop/day-in-the-life
