### PR TITLE
add molecule to jenkins-slave-ansible Dockerfile

### DIFF
--- a/jenkins-agents/jenkins-agent-ansible/Dockerfile
+++ b/jenkins-agents/jenkins-agent-ansible/Dockerfile
@@ -18,13 +18,15 @@ RUN INSTALL_PKGS="rh-python36-python-pip" && \
     yum $DISABLE_REPOS install -y $INSTALL_PKGS && \
     source scl_source enable rh-python36 && \
     scl enable rh-python36 bash && \
-    python3 -m pip install ansible==$ANSIBLE_VERSION paramiko && \
+    python3 -m pip install ansible==$ANSIBLE_VERSION paramiko molecule && \
     yum $DISABLE_REPOS clean all -y && \
     rm -rf /var/cache/yum
 
 ADD scl_enable /usr/share/container-scripts/
 ENV BASH_ENV=/usr/share/container-scripts/scl_enable \
     ENV=/usr/share/container-scripts/scl_enable \
-    PROMPT_COMMAND="./usr/share/container-scripts/scl_enable"
+    PROMPT_COMMAND="./usr/share/container-scripts/scl_enable" \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
 
 USER 1001

--- a/jenkins-agents/jenkins-agent-ansible/Jenkinsfile.test
+++ b/jenkins-agents/jenkins-agent-ansible/Jenkinsfile.test
@@ -8,6 +8,7 @@ pipeline {
             steps {
                 sh """
                     ansible --version
+                    molecule --version
                 """
             }
         }


### PR DESCRIPTION
#### What is this PR About?
Describe the contents of the PR

Add molecule to pip install in jenkins-slave-ansible. As well, needed to set LC_ALL and LANG as ENV for molecule to work


#### How do we test this?
Provide commands/steps to test this PR.

Locally,

Build locally, and then run molecule --version in running container

On OCP,

Process and template (command provided in README).

Run sample pipeline using jenkins-slave-ansible label and use molecule command.

This should create an image stream with a jenkins-slave label, so that Jenkins picks it up as an available slave. 

```
pipeline {
  
  agent {
    label 'jenkins-slave-ansible'
  }

  stages {

    stage ('Get latest code') {
      steps {
        checkout scm
      }
    }

    stage ('Molecule check') {
      steps {
        sh '''
          ansible --version
          molecule --version
        '''
      }
    }

  }

}

```

cc: @redhat-cop/day-in-the-life
