### PR TITLE
tool-box: Fixing README bug + updating versions

### DIFF
--- a/tool-box/Dockerfile
+++ b/tool-box/Dockerfile
@@ -1,17 +1,15 @@
 FROM registry.access.redhat.com/ubi8
 
-MAINTAINER Aly Ibrahim<aly@redhat.com>
-
-ENV OC_VERSION=4.4.7 \
-    ODO_VERSION=v1.2.1 \
+ENV OC_VERSION=4.5.10 \
+    ODO_VERSION=v1.2.6 \
     ANSIBLE_VERSION=2.9 \
     JQ_VERSION=1.6 \
     HELM_VERSION=v3.2.3 \
-    TEKTON_VERSION=0.9.0 \
-    HOME=/home/tool-box
+    TEKTON_VERSION=0.12.1 \
+    HOME=/home/tool-box \
+    INSTALL_PKGS="git vim unzip python36"
 
 RUN yum -y update && \
-    INSTALL_PKGS="git vim unzip python36" && \
     yum -y install $INSTALL_PKGS && \
     yum clean all
 

--- a/tool-box/README.md
+++ b/tool-box/README.md
@@ -32,11 +32,11 @@ Build the container and deploy it in OpenShift:
 
 Run the container in the background, then shell into. There are important things the container does at boot that you don't want to override. If you need sudo for docker:
 
-`$ sudo docker run -it tool-box /bin/bash`
+`$ sudo docker run -it redhat-cop/tool-box /bin/bash`
 
 If you don't need sudo:
 
-`$ docker run -it tool-box /bin/bash`
+`$ docker run -it redhat-cop/tool-box /bin/bash`
 
 ## Building the Image
 


### PR DESCRIPTION
#### What is this PR About?
The README for the `tool-box` had the wrong command to run with `docker., which is now fixed + bumping versions of various components to the latest stable versions. 

#### How do we test this?
Run the `tool-box` container 

cc: @redhat-cop/day-in-the-life
