### PR TITLE
Update asciidoctor image to latest released versions

### DIFF
--- a/utilities/ubi8-asciidoctor/Dockerfile
+++ b/utilities/ubi8-asciidoctor/Dockerfile
@@ -44,7 +44,7 @@ RUN microdnf install \
 
 # install pandoc
 RUN curl -L https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -o pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz
-RUN tar xvzf pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz --strip-components 1 -C /usr/local/ 
+RUN tar xvzf pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz --strip-components 1 -C /usr/local/
 
 # Installing Ruby Gems needed in the image
 # including asciidoctor itself

--- a/utilities/ubi8-asciidoctor/Dockerfile
+++ b/utilities/ubi8-asciidoctor/Dockerfile
@@ -5,12 +5,12 @@ LABEL MAINTAINERS="Red Hat Services"
 ARG asciidoctor_version=2.0.10
 ARG asciidoctor_confluence_version=0.0.2
 ARG asciidoctor_pdf_version=1.5.3
-ARG asciidoctor_diagram_version=1.5.19
-ARG asciidoctor_epub3_version=1.5.0.alpha.12
+ARG asciidoctor_diagram_version=2.0.1
+ARG asciidoctor_epub3_version=1.5.0.alpha.18
 ARG asciidoctor_mathematical_version=0.3.1
-ARG asciidoctor_revealjs_version=2.0.0
+ARG asciidoctor_revealjs_version=4.0.1
 ARG kramdown_asciidoc_version=1.0.1
-ARG pandoc_version=2.9.2.1
+ARG pandoc_version=2.10.1
 
 
 ENV ASCIIDOCTOR_VERSION=${asciidoctor_version} \
@@ -39,11 +39,12 @@ RUN microdnf install \
   patch \
   git \
   gcc-c++ \
-  glib2-devel
+  glib2-devel \
+  && microdnf clean all
 
 # install pandoc
-RUN curl -L https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -o pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz
-RUN tar xvzf pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz --strip-components 1 -C /usr/local/
+RUN curl -L https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -o pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz 
+RUN  tar xvzf pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz --strip-components 1 -C /usr/local/ 
 
 # Installing Ruby Gems needed in the image
 # including asciidoctor itself
@@ -67,10 +68,10 @@ RUN gem install --no-document \
 
 # Installing Python dependencies for additional
 # functionnalities as diagrams or syntax highligthing
-RUN pip3 install \
+RUN pip3 install --no-cache-dir \
     actdiag \
     'blockdiag[pdf]' \
-    nwdiag \
+    'nwdiag[pdf]' \
     seqdiag
 
 WORKDIR /documents

--- a/utilities/ubi8-asciidoctor/Dockerfile
+++ b/utilities/ubi8-asciidoctor/Dockerfile
@@ -59,7 +59,6 @@ RUN gem install --no-document \
     coderay \
     epubcheck-ruby:4.2.2.0 \
     haml \
-    kindlegen:3.0.5 \
     "kramdown-asciidoc:${KRAMDOWN_ASCIIDOC_VERSION}" \
     rouge \
     slim \

--- a/utilities/ubi8-asciidoctor/Dockerfile
+++ b/utilities/ubi8-asciidoctor/Dockerfile
@@ -43,8 +43,8 @@ RUN microdnf install \
   && microdnf clean all
 
 # install pandoc
-RUN curl -L https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -o pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz 
-RUN  tar xvzf pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz --strip-components 1 -C /usr/local/ 
+RUN curl -L https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -o pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz
+RUN tar xvzf pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz --strip-components 1 -C /usr/local/ 
 
 # Installing Ruby Gems needed in the image
 # including asciidoctor itself

--- a/utilities/ubi8-asciidoctor/version.json
+++ b/utilities/ubi8-asciidoctor/version.json
@@ -1,1 +1,1 @@
-{"version":"v1.1"}
+{"version":"v1.2"}


### PR DESCRIPTION
#### What is this PR About?
Describe the contents of the PR
- Updates the images to the latest released asciidoctor products
- removed kindlegen product because upstream (asciidoctor did this also) 
- update version.json from 1.1 into 1.2

#### How do we test this?
Provide commands/steps to test this PR.
Create the image and check the output of the pdf ....
docker run --rm --name asciidoctor -v /<report-dir>/:/documents/ -w /documents/styles quay.io/redhat-cop/ubi8-asciidoctor:1.2 asciidoctor-pdf -r asciidoctor-diagram -a ej-base-dir=/documents/  <document.adoc>
cc: @redhat-cop/day-in-the-life
