### PR TITLE
Make utilities/ubi8-asciidoctor image significantly smaller

### DIFF
--- a/utilities/ubi8-asciidoctor/Dockerfile
+++ b/utilities/ubi8-asciidoctor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi8
 
 LABEL MAINTAINERS="Red Hat Services"
 
@@ -26,30 +26,32 @@ ENV ASCIIDOCTOR_VERSION=${asciidoctor_version} \
 
 USER root
 
-RUN microdnf install \
+RUN dnf install -y \
   tar \
   gzip \
-  make \
-  cmake \
   python3 \
   python3-setuptools \
-  ruby-devel \
-  gcc redhat-rpm-config \
-  zlib-devel \
-  patch \
   git \
-  gcc-c++ \
-  glib2-devel \
-  && microdnf clean all
+  ruby \
+  && dnf clean all && rm -rf /var/lib/dnf && rm -rf /usr/share/doc
 
 # install pandoc
-RUN curl -L https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -o pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz
-RUN tar xvzf pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz --strip-components 1 -C /usr/local/
+RUN curl -L https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz | tar xvz --strip-components 1 -C /usr/local/
 
 # Installing Ruby Gems needed in the image
 # including asciidoctor itself
 # TODO: have to find Lasem dev libs     "asciidoctor-mathematical:${ASCIIDOCTOR_MATHEMATICAL_VERSION}" \
-RUN gem install --no-document \
+
+RUN dnf install -y \
+  make \
+  cmake \
+  ruby-devel \
+  gcc redhat-rpm-config \
+  zlib-devel \
+  patch \
+  gcc-c++ \
+  glib2-devel \
+  && gem install --no-document \
     "asciidoctor:${ASCIIDOCTOR_VERSION}" \
     "asciidoctor-confluence:${ASCIIDOCTOR_CONFLUENCE_VERSION}" \
     "asciidoctor-diagram:${ASCIIDOCTOR_DIAGRAM_VERSION}" \
@@ -64,7 +66,9 @@ RUN gem install --no-document \
     rouge \
     slim \
     thread_safe \
-    tilt
+    tilt \
+  && rm -rf /usr/local/share/gems/cache \
+  && dnf history undo last -y && dnf clean all && rm -rf /var/lib/dnf
 
 # Installing Python dependencies for additional
 # functionnalities as diagrams or syntax highligthing

--- a/utilities/ubi8-asciidoctor/version.json
+++ b/utilities/ubi8-asciidoctor/version.json
@@ -1,1 +1,1 @@
-{"version":"v1.2"}
+{"version":"v1.3"}


### PR DESCRIPTION
#### What is this PR About?
* Use ubi8 instead of ubi8-minimal.
  When installing so much (esp. python) there's barely any difference.
  Yet, one can leverage full dnf in ubi8
* Less layers with curl | tar
* Install gcc, make etc. -> install gems -> remove gcc, make etc. all in one layer
  This saves up to 300M
* Cleanup cache and docs where reasonable

#### How do we test this?

Create the image and check the output of the pdf ....
```bash
podman run --rm --name asciidoctor -v //:/documents/ -w /documents/styles quay.io/redhat-cop/ubi8-asciidoctor:1.3 asciidoctor-pdf -r asciidoctor-diagram -a ej-base-dir=/documents/<document.adoc>
```

cc: @redhat-cop/day-in-the-life
