### PR TITLE
refactor dockerfile & update Jenkins base to 4.5

### DIFF
--- a/jenkins-agents/jenkins-agent-ansible/Dockerfile
+++ b/jenkins-agents/jenkins-agent-ansible/Dockerfile
@@ -1,32 +1,44 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.4
+FROM quay.io/openshift/origin-jenkins-agent-base:4.5
+ARG ANSIBLE_VERSION=2.9.13
 
-LABEL com.redhat.component="jenkins-agent-ansible-ubi7-docker" \
-      name="openshift/origin-jenkins-agent-ansible-ubi7" \
-      version="4.4" \
-      architecture="x86_64" \
+LABEL \
       release="1" \
+      version="4.5" \
+      architecture="x86_64" \
       io.k8s.display-name="Jenkins Agent Ansible" \
-      io.k8s.description="The jenkins agent ansible image has ansible on top of the jenkins agent base image." \
-      io.openshift.tags="openshift,jenkins,agent,ansible"
+      name="openshift/origin-jenkins-agent-ansible-ubi7" \
+      io.openshift.tags="openshift,jenkins,agent,ansible" \
+      com.redhat.component="jenkins-agent-ansible-ubi7-docker" \
+      io.k8s.description="The jenkins agent ansible image has ansible on top of the jenkins agent base image."
 
-ENV ANSIBLE_VERSION=2.9.13
+ARG DISABLE_REPOS=--disablerepo="rhel-*"
+ARG YUM_FLAGS="${DISABLE_REPOS} -y -q"
+
+ARG PIP_PKGS="\
+        molecule \
+        paramiko \
+        ansible==${ANSIBLE_VERSION} \
+"
+ARG YUM_PKGS="\
+        rh-python36-python-pip \
+"
 
 ADD ubi.repo /etc/yum.repos.d/ubi.repo
-
-RUN INSTALL_PKGS="rh-python36-python-pip" && \
-    DISABLE_REPOS=--disablerepo='rhel-*' && \
-    yum $DISABLE_REPOS install -y $INSTALL_PKGS && \
-    source scl_source enable rh-python36 && \
-    scl enable rh-python36 bash && \
-    python3 -m pip install ansible==$ANSIBLE_VERSION paramiko molecule && \
-    yum $DISABLE_REPOS clean all -y && \
-    rm -rf /var/cache/yum
-
 ADD scl_enable /usr/share/container-scripts/
-ENV BASH_ENV=/usr/share/container-scripts/scl_enable \
-    ENV=/usr/share/container-scripts/scl_enable \
-    PROMPT_COMMAND="./usr/share/container-scripts/scl_enable" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8
+
+USER root
+RUN set -x \
+     && yum install ${YUM_FLAGS} ${YUM_PKGS} \
+     && yum ${YUM_FLAGS} clean all \
+     && rm -rf /var/cache/yum \
+     && source scl_source enable rh-python36 \
+     && python3 -m pip install ${PIP_PKGS} \
+    && echo
 
 USER 1001
+ENV \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    ENV=/usr/share/container-scripts/scl_enable \
+    BASH_ENV=/usr/share/container-scripts/scl_enable \
+    PROMPT_COMMAND="./usr/share/container-scripts/scl_enable"


### PR DESCRIPTION
Improvements:
  - Update jenkins base image from 4.4 > 4.5 (prep for move from ubi7 to ubi8)
  - Reformat Dockerfile for ease of troubleshooting / testing
  - Remove user-interactive build breaking cmd
  - Flip ansible version from env to arg
  - Variablize yum install flags
  - Variablize Pip & yum package instal lists
  - Enable BASH_XTRACEFD for improved build pipeline debugging

Build as usual to test.

cc: @redhat-cop/day-in-the-life