### PR TITLE
Adding vanity route + cert OCP template

### DIFF
--- a/cert-manager-configs/.openshift/cert-manager.yml
+++ b/cert-manager-configs/.openshift/cert-manager.yml
@@ -1,6 +1,6 @@
 ---
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     description: Cert Manager Deployment to support Acme Certificates

--- a/cert-manager-configs/.openshift/cert-utils-operator.yml
+++ b/cert-manager-configs/.openshift/cert-utils-operator.yml
@@ -1,6 +1,6 @@
 ---
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     description: Cert Manager Deployment to support Acme Certificates

--- a/cert-manager-configs/.openshift/ocpv4-certs.yml
+++ b/cert-manager-configs/.openshift/ocpv4-certs.yml
@@ -1,6 +1,6 @@
 ---
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     description: OCP v4 Certificate and Configuration to load the certs

--- a/cert-manager-configs/.openshift/route-with-cert.yml
+++ b/cert-manager-configs/.openshift/route-with-cert.yml
@@ -16,8 +16,8 @@ objects:
     spec:
       secretName: "${NAME}-certificate"
       issuerRef:
-        name: letsencrypt-production
-        kind: ClusterIssuer
+        name: "${ISSUER_REF_NAME}"
+        kind: "${ISSUER_REF_KIND}"
       dnsNames:
         - "${FQDN}"
   - kind: Route
@@ -54,3 +54,7 @@ parameters:
   - name: TARGET_PORT
     description: The target port for the route
     value: 8080-tcp
+  - name: ISSUER_REF_NAME
+    value: letsencrypt-production
+  - name: ISSUER_REF_KIND
+    value: ClusterIssuer

--- a/cert-manager-configs/.openshift/route-with-cert.yml
+++ b/cert-manager-configs/.openshift/route-with-cert.yml
@@ -1,6 +1,6 @@
 ---
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     description: Vanity Certificate and Configuration to manage a vanity route with a valid cert

--- a/cert-manager-configs/.openshift/route-with-cert.yml
+++ b/cert-manager-configs/.openshift/route-with-cert.yml
@@ -1,0 +1,56 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  annotations:
+    description: Vanity Certificate and Configuration to manage a vanity route with a valid cert
+  name: "vanity-certificate"
+labels:
+  template: "vanity-certificate"
+objects:
+  - kind: Certificate
+    apiVersion: cert-manager.io/v1alpha2
+    metadata:
+      name: "${NAME}-certificate"
+      namespace: ${NAMESPACE}
+    spec:
+      secretName: "${NAME}-certificate"
+      issuerRef:
+        name: letsencrypt-production
+        kind: ClusterIssuer
+      dnsNames:
+        - "${FQDN}"
+  - kind: Route
+    apiVersion: route.openshift.io/v1
+    metadata:
+      annotations:
+        cert-utils-operator.redhat-cop.io/certs-from-secret: "${NAME}-certificate"
+      labels:
+        app: "${NAME}"
+      name: "${NAME}"
+      namespace: "${NAMESPACE}"
+    spec:
+      host: "${FQDN}"
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: edge
+      port:
+        targetPort: "${TARGET_PORT}"
+      to:
+        kind: Service
+        name: "${NAME}"
+        weight: 100
+      wildcardPolicy: None
+parameters:
+  - name: NAME
+    description: Name of the Deployment/Route
+    required: true
+  - name: NAMESPACE
+    description: The namespace used for the route and certificate
+    required: true
+  - name: FQDN
+    description: The FQDN to use for the route and certificate
+    required: true
+  - name: TARGET_PORT
+    description: The target port for the route
+    value: 8080-tcp

--- a/cert-manager-configs/.openshift/route-with-cert.yml
+++ b/cert-manager-configs/.openshift/route-with-cert.yml
@@ -4,9 +4,9 @@ apiVersion: v1
 metadata:
   annotations:
     description: Vanity Certificate and Configuration to manage a vanity route with a valid cert
-  name: "vanity-certificate"
+  name: "vanity-route-certificate"
 labels:
-  template: "vanity-certificate"
+  template: "vanity-route-certificate"
 objects:
   - kind: Certificate
     apiVersion: cert-manager.io/v1alpha2


### PR DESCRIPTION
#### What is this PR About?
Follow-up PR to #403 to allow for OCP template use to create a vanity route with valid certificate

#### How do we test this?
Run the oc process command, e.g.:

```
oc process --local -f route-with-cert.yml -p NAME=test -p NAMESPACE=test -p FQDN=test.example.com -o yaml
```

cc: @redhat-cop/day-in-the-life
