### PR TITLE
fix images to java:8 and nodejs:10 for hygieia

### DIFF
--- a/hygieia/.openshift/templates/build-base-image.yml
+++ b/hygieia/.openshift/templates/build-base-image.yml
@@ -29,7 +29,7 @@ objects:
       dockerStrategy:
         from:
           kind: ImageStreamTag
-          name: java:latest
+          name: java:8
           namespace: openshift
       type: Docker
     successfulBuildsHistoryLimit: 5

--- a/hygieia/.openshift/templates/build-exec-ui.yml
+++ b/hygieia/.openshift/templates/build-exec-ui.yml
@@ -39,7 +39,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: nodejs:8
+          name: nodejs:10
           namespace: openshift
       type: Source
     triggers:

--- a/hygieia/.openshift/templates/build-hygieia-jenkins-collector.yml
+++ b/hygieia/.openshift/templates/build-hygieia-jenkins-collector.yml
@@ -45,7 +45,7 @@ objects:
           value: -pl collectors/build/jenkins -am
         from:
           kind: ImageStreamTag
-          name: java:latest
+          name: java:8
           namespace: openshift
       type: Source
     output: 

--- a/hygieia/.openshift/templates/build-java-component.yml
+++ b/hygieia/.openshift/templates/build-java-component.yml
@@ -44,7 +44,7 @@ objects:
           value: -pl ${COMPONENT} -am
         from:
           kind: ImageStreamTag
-          name: java:latest
+          name: java:8
           namespace: openshift
       type: Source
     triggers:

--- a/hygieia/.openshift/templates/build-ui.yml
+++ b/hygieia/.openshift/templates/build-ui.yml
@@ -39,7 +39,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: nodejs:8
+          name: nodejs:10
           namespace: openshift
       type: Source
     triggers:


### PR DESCRIPTION
#### What is this PR About?
Fixing image versions (nodejs:8 not in 4.5 openshift and java:latest will not build - so fixed to java:8)
#### How do we test this?
Ensure playbook runs and app stands up.  Tested locally with:
```
export ANSIBLE_INVALID_TASK_ATTRIBUTE_FAILED=False
ansible-playbook -i .applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e filter_tags=all -e skip_version_checks=true
```
cc: @redhat-cop/day-in-the-life
