### PR TITLE
asiidoctor-pdf: Add HOME env

### DIFF
--- a/utilities/ubi8-asciidoctor/Dockerfile
+++ b/utilities/ubi8-asciidoctor/Dockerfile
@@ -81,6 +81,8 @@ RUN pip3 install --no-cache-dir \
 WORKDIR /documents
 VOLUME /documents
 
+ENV HOME=/documents
+
 USER 1001
 
 CMD ["/bin/bash"]

--- a/utilities/ubi8-asciidoctor/version.json
+++ b/utilities/ubi8-asciidoctor/version.json
@@ -1,1 +1,1 @@
-{"version":"v1.3"}
+{"version":"v1.4"}


### PR DESCRIPTION
Without it, the user has / as home implicitly,
which breaks some commands that create files in users home


cc: @redhat-cop/day-in-the-life
