### PR TITLE
Update cert-utils-operator target namespaces

### DIFF
--- a/cert-manager-configs/.openshift/cert-utils-operator.yml
+++ b/cert-manager-configs/.openshift/cert-utils-operator.yml
@@ -20,13 +20,7 @@ objects:
       name: cert-utils-operator
     spec:
       channel: alpha
-      installPlanApproval: ${INSTALL_PLAN_APPROVAL}
+      installPlanApproval: Automatic
       name: cert-utils-operator
       source: community-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: ${STARTING_CSV}
-parameters:
-  - name: STARTING_CSV
-    value: cert-utils-operator.v1.0.1
-  - name: INSTALL_PLAN_APPROVAL
-    value: Manual

--- a/cert-manager-configs/.openshift/cert-utils-operator.yml
+++ b/cert-manager-configs/.openshift/cert-utils-operator.yml
@@ -13,18 +13,20 @@ objects:
     metadata:
       name: cert-utils
     spec:
-      targetNamespaces:
-        - ${NAMESPACE}
+      targetNamespaces: []
   - kind: Subscription
     apiVersion: operators.coreos.com/v1alpha1
     metadata:
       name: cert-utils-operator
     spec:
       channel: alpha
-      installPlanApproval: Automatic
+      installPlanApproval: ${INSTALL_PLAN_APPROVAL}
       name: cert-utils-operator
       source: community-operators
       sourceNamespace: openshift-marketplace
+      startingCSV: ${STARTING_CSV}
 parameters:
-  - name: NAMESPACE
-    value: cert-mgmt
+  - name: STARTING_CSV
+    value: cert-utils-operator.v1.0.1
+  - name: INSTALL_PLAN_APPROVAL
+    value: Manual


### PR DESCRIPTION
#### What is this PR About?

Latest cert-utils-operator supports `AllNamespaces` rather than `SingleNamespace` install mode. Adding an empty list will allow the operator installation to properly complete.

#### How do we test this?
This can be installed independently with the following

```bash
oc process --local -f cert-manager-configs/.openshift/cert-utils-operator.yml | oc apply -f -
```

cc: @redhat-cop/day-in-the-life
