### PR TITLE
🐟 mandrel drop in 🐟

### DIFF
--- a/jenkins-agents/jenkins-agent-argocd/Dockerfile
+++ b/jenkins-agents/jenkins-agent-argocd/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-jenkins-agent-base:4.6
 
-ENV ARGOCD_VERSION=1.8.1 \
-    YQ_VERSION=3.4.1
+ENV ARGOCD_VERSION=1.8.3 \
+    YQ_VERSION=4.5.0
 
 RUN curl -sL  https://github.com/argoproj/argo-cd/releases/download/v${ARGOCD_VERSION}/argocd-linux-amd64 -o /usr/local/bin/argocd && \
     chmod -R 775 /usr/local/bin/argocd && \

--- a/jenkins-agents/jenkins-agent-graalvm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-graalvm/Dockerfile
@@ -1,5 +1,11 @@
 FROM quay.io/openshift/origin-jenkins-agent-maven:4.6
-ARG GRAALVM_VERSION=20.2.0
+ARG GRAAL_VERSION=20.3.1.2.Final
+ENV GRAALVM_HOME=/opt/mandrelJDK
+ENV GRAAL_CE_URL=https://github.com/graalvm/mandrel/releases/download/mandrel-${GRAAL_VERSION}/mandrel-java11-linux-amd64-${GRAAL_VERSION}.tar.gz
+ARG HELM_VERSION=3.5.2
+ARG JQ_VERSION=1.6
+ARG OC_VERSION=4.6
+ARG YQ_VERSION=4.5.1
 
 ADD settings.xml $HOME/.m2/settings.xml
 ADD ubi8.repo /tmp/ubi8.repo
@@ -8,9 +14,21 @@ USER root
 RUN rm -f /etc/yum.repos.d/*.repo && \
     mv /tmp/ubi8.repo /etc/yum.repos.d/ubi8.repo && \
     dnf install -y gcc glibc-devel zlib-devel && \
-    mkdir /opt/graalvm && \
-    curl -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAALVM_VERSION}/graalvm-ce-java11-linux-amd64-${GRAALVM_VERSION}.tar.gz | tar --strip-components=1 -xz -C /opt/graalvm/ && \
-    /opt/graalvm/bin/gu install native-image
+    ### tools
+    mkdir -p ${GRAALVM_HOME} && \
+    cd ${GRAALVM_HOME} && \
+    curl -fsSL $GRAAL_CE_URL | tar -xzC ${GRAALVM_HOME} --strip-components=1 && \
+    curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 && \
+    chmod +x /usr/local/bin/jq && \
+    curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar --strip-components=1 -C /usr/local/bin -xzf - linux-amd64/helm && \
+    curl -Lo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 && \
+    chmod +x /usr/local/bin/yq && \
+    rm -f /usr/bin/oc && \
+    curl -L http://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz | tar -C /usr/local/bin -xzf - && \
+    ### Cleanup
+    dnf clean all && \
+    rm -rf /var/cache/yum
+
 USER 1001
-ENV GRAALVM_HOME /opt/graalvm
-ENV PATH /opt/rh/rh-maven35/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/graalvm/bin
+WORKDIR ${USER_HOME_DIR}
+ENV PATH ${PATH}:${GRAALVM_HOME}/bin

--- a/jenkins-agents/jenkins-agent-graalvm/Jenkinsfile.test
+++ b/jenkins-agents/jenkins-agent-graalvm/Jenkinsfile.test
@@ -7,8 +7,13 @@ pipeline {
         stage ('Run Test') {
             steps {
               sh """
+                  java --version
                   mvn --version
                   native-image --version
+                  oc version --client
+                  helm version
+                  jq --version
+                  yq --version
               """
             }
         }

--- a/jenkins-agents/jenkins-agent-graalvm/README.md
+++ b/jenkins-agents/jenkins-agent-graalvm/README.md
@@ -1,12 +1,28 @@
 # Jenkins GraalVM Agent
 
+This image contains the following tools:
+
+- jenkins agent (default entrypoint)
+- Open jdk 1.11 and native-image from Mandrel (default - /opt/mandrelJDK)
+- Open jdk 1.8, 1.11 from the base image (/usr/lib/jvm/)
+- helm3 client
+- oc client
+- yq, jq tools
+
+The image is setup to use jdk 1.11 and native-image from Mandrel, but you may set JAVA_HOME to other versions in this image if needed.
+```
+
+## GraalVM
+
 [GraalVM](https://www.graalvm.org/docs/introduction/) is a high-performance runtime that provides significant improvements in application performance and efficiency which is ideal for microservices. It is designed for applications written in Java, JavaScript, LLVM-based languages such as C and C++, and other dynamic languages. It removes the isolation between programming languages and enables interoperability in a shared runtime.
 
 This agent extends [the Jenkins Maven Agent shipped with OpenShift](https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/openshift3/jenkins-agent-maven-rhel7) to provide a settings.xml that proxies all dependencies through a nexus server deployed to the same namespace. This type of setup makes sense in a Lab setting, such as [Open Innovation Labs CI/CD](https://github.com/rht-labs/labs-ci-cd) environment. For most customer engagements, you'll to update this proxy/password to use an central, enterprise artifact repo which is unlikely to be deployed in the same namespace. Or simply use the OpenShift supplied base image directly and provide artifact repository info in the application build.
 
-## GraalVM Native Image
+## Native Image
 
 [GraalVM Native Image](https://www.graalvm.org/reference-manual/native-image/) allows to ahead-of-time compile Java code to a standalone executable, called a native image. This executable includes the application classes, classes from its dependencies, runtime library classes from JDK and statically linked native code from JDK. It does not run on the Java VM, but includes necessary components like memory management and thread scheduling from a different virtual machine, called “Substrate VM”. Substrate VM is the name for the runtime components (like the deoptimizer, garbage collector, thread scheduling etc.). The resulting program has faster startup time and lower runtime memory overhead compared to a Java VM.
+
+[Mandrel](https://github.com/graalvm/mandrel) Mandrel is a downstream distribution of the GraalVM community edition. Mandrel's main goal is to provide a native-image release specifically to support Quarkus. Madrel [differs](https://github.com/graalvm/mandrel#how-does-mandrel-differ-from-graal) from Graal in that it does not include support for the image build server and Polyglot programming via the Truffle interpreter and compiler framework.
 
 ## Build in OpenShift
 ```bash

--- a/jenkins-agents/jenkins-agent-zap/Dockerfile
+++ b/jenkins-agents/jenkins-agent-zap/Dockerfile
@@ -16,6 +16,7 @@ RUN yum install -y epel-release && \
     firefox nss_wrapper java-1.8.0-openjdk-headless \
     java-1.8.0-openjdk-devel nss_wrapper && \
     yum clean all && \
+    curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py && chmod 755 get-pip.py && ./get-pip.py && \
     pip install --upgrade pip && \
     pip install zapcli && \
     pip install python-owasp-zap-v2.4 && \


### PR DESCRIPTION
#### What is this PR About?
updates the graalvm jenkins agent to use the madrel drop in replacement
add in common tools (updated oc, helm, yq, yq)

supercedes/replaces - https://github.com/redhat-cop/containers-quickstarts/pull/429

#### How do we test this?
See Jenkinsfile test

cc: @redhat-cop/day-in-the-life
