### PR TITLE
Fix to helm-agent-argocd

### DIFF
--- a/jenkins-agents/jenkins-agent-argocd/Dockerfile
+++ b/jenkins-agents/jenkins-agent-argocd/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-jenkins-agent-base:4.6
 
 ENV ARGOCD_VERSION=1.8.3 \
-    YQ_VERSION=4.5.0
+    YQ_VERSION=v4.5.1
 
 RUN curl -sL  https://github.com/argoproj/argo-cd/releases/download/v${ARGOCD_VERSION}/argocd-linux-amd64 -o /usr/local/bin/argocd && \
     chmod -R 775 /usr/local/bin/argocd && \


### PR DESCRIPTION
#### What is this PR About?
The `YQ_VERSION` should be vX.Y.Z. 

I've also bumped the `YQ_VERSION` to 4.5.1 whilst I'm at it.

Closes #438 

#### How do we test this?
Build argocd agent and run `yq` command and see it works

cc: @redhat-cop/day-in-the-life
