### PR TITLE
Bump YQ_VERSION to 4.5.1

### DIFF
--- a/jenkins-agents/jenkins-agent-helm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-helm/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-jenkins-agent-base:4.6
 
 ARG VERSION=3.2.0
-ARG YQ_VERSION=4.5.1
+ARG YQ_VERSION=v4.5.1
 ARG CT_VERSION=3.0.0-rc.1
 ARG OPENSHIFT_CLIENT_VERSION=4.4.13
 

--- a/jenkins-agents/jenkins-agent-helm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-helm/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-jenkins-agent-base:4.6
 
 ARG VERSION=3.2.0
-ARG YQ_VERSION=3.3.0
+ARG YQ_VERSION=4.5.1
 ARG CT_VERSION=3.0.0-rc.1
 ARG OPENSHIFT_CLIENT_VERSION=4.4.13
 


### PR DESCRIPTION
#### What is this PR About?
yq v3 will not be supported beyond August so probably best to move onto this, especially as the `jenkins-agent-argocd` is already using yq v4. There are compatibility issues between 3 and 4 (something I have found on the argocd agent, [see the yq docs](https://mikefarah.gitbook.io/yq/v/v4.x/upgrading-from-v3) for more details).

I haven't made a change on all the other YQ_VERSIONS in this repo as they are for the testing frameworks etc. which I think could break other things elsewhere.

#### How do we test this?
N/A

cc: @redhat-cop/day-in-the-life
