### PR TITLE
FIX: fix for jenkins-agent-conftest build failure

### DIFF
--- a/jenkins-agents/jenkins-agent-conftest/Dockerfile
+++ b/jenkins-agents/jenkins-agent-conftest/Dockerfile
@@ -1,21 +1,18 @@
 FROM quay.io/redhat-cop/jenkins-agent-python:v1.0
 # ^ needed to install the python yq library 🐍
 
-ENV BATS_VERSION=1.2.0 \
-    YQ_VERSION=3.3.2 \
-    CONFTEST_VERSION=0.18.2
+ARG BATS_VERSION=1.2.0
+ARG YQ_VERSION=2.12.0
+ARG CONFTEST_VERSION=0.23.0
 
 USER root
 
-RUN curl --fail -skL https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz -o /tmp/conftest.tar.gz && \ 
-    tar -C /tmp -xzf /tmp/conftest.tar.gz && \
-    mv /tmp/conftest /usr/local/bin && \
-    curl --fail -sL  https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz -o  /tmp/bats.tar.gz && \
-    tar -C /tmp -xzf /tmp/bats.tar.gz && \
+RUN curl --fail -skL https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz | tar zxf - -C /usr/local/bin conftest && \
+    curl --fail -sL  https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz | tar zxf - -C /tmp && \
     ./tmp/bats-core-${BATS_VERSION}/install.sh /usr/local && \
     echo "na na na na na na na na na 🦇👨‍🦰" && \
     rm -rf /tmp/conftest.tar.gz /tmp/bats* && \
     chmod -R 775 /usr/local/bin/bats /usr/local/bin/conftest && \
-    scl enable rh-python36 'python3 -m pip install yq'
+    pip install yq==${YQ_VERSION}
 
 USER 1001


### PR DESCRIPTION
#### What is this PR About?
This image is currently failing to build which this PR fixes. It also include some cleanup and version updates.
```
STEP 1: FROM quay.io/redhat-cop/jenkins-agent-python:v1.0
Getting image source signatures
Copying blob 791696e2ff97 done
Copying blob 911e72d1d7d7 done
Copying blob fecf0868d374 done
Copying blob 0c983affa284 done
Copying blob f7db571f3a05 done
Copying blob 050d08c748fb done
Copying blob b9ef6a88723f done
Copying blob f4f449dd7a0e done
Copying blob 48d8cd37b9f4 done
Copying config e68a2afeef done
Writing manifest to image destination
Storing signatures
STEP 2: ENV BATS_VERSION=1.2.0     YQ_VERSION=3.3.2     CONFTEST_VERSION=0.18.2
STEP 3: USER root
STEP 4: RUN curl --fail -skL https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${
CONFTEST_VERSION}_Linux_x86_64.tar.gz -o /tmp/conftest.tar.gz &&     tar -C /tmp -xzf /tmp/conftest.tar.gz &&     mv /tmp/con
ftest /usr/local/bin &&     curl --fail -sL  https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz -o  /tmp/
bats.tar.gz &&     tar -C /tmp -xzf /tmp/bats.tar.gz &&     ./tmp/bats-core-${BATS_VERSION}/install.sh /usr/local &&     echo
 "na na na na na na na na na 🦇👨‍🦰" &&     rm -rf /tmp/conftest.tar.gz /tmp/bats* &&     chmod -R 775 /usr/local/bin/bats /u
sr/local/bin/conftest &&     scl enable rh-python36 'python3 -m pip install yq'
Installed Bats to /usr/local/bin/bats
na na na na na na na na na 🦇👨‍🦰
/bin/sh: scl: command not found
error building at STEP "RUN curl --fail -skL https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERS
ION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz -o /tmp/conftest.tar.gz &&     tar -C /tmp -xzf /tmp/conftest.tar.gz &&
     mv /tmp/conftest /usr/local/bin &&     curl --fail -sL  https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.
tar.gz -o  /tmp/bats.tar.gz &&     tar -C /tmp -xzf /tmp/bats.tar.gz &&     ./tmp/bats-core-${BATS_VERSION}/install.sh /usr/l
ocal &&     echo "na na na na na na na na na 🦇👨‍🦰" &&     rm -rf /tmp/conftest.tar.gz /tmp/bats* &&     chmod -R 775 /usr/l
ocal/bin/bats /usr/local/bin/conftest &&     scl enable rh-python36 'python3 -m pip install yq'": error while running runtime
: exit status 127
ERRO exit status 127"
```

#### How do we test this?
Run the `Jenkinsfile.test` pipeline

cc: @redhat-cop/day-in-the-life
