### PR TITLE
Change RabbitMQ to use ubi-minimal:8

### DIFF
--- a/rabbitmq/.openshift/templates/builds/template.yml
+++ b/rabbitmq/.openshift/templates/builds/template.yml
@@ -68,7 +68,7 @@ parameters:
 - description: Image stream tag for the image you'd like to use to build the application
   name: FROM_IMAGE
   required: true
-  value: ubi:7.7
+  value: ubi-minimal:8.3
 - description: RabbitMQ Autocluster version to use
   name: RABBITMQ_AUTOCLUSTER_VERSION
   required: true

--- a/rabbitmq/.openshift/templates/imagestreams/images.yml
+++ b/rabbitmq/.openshift/templates/imagestreams/images.yml
@@ -4,24 +4,24 @@ items:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
-    name: ubi
+    name: ubi-minimal
   spec:
-    dockerImageRepository: registry.access.redhat.com/ubi7/ubi
+    dockerImageRepository: registry.access.redhat.com/ubi8/ubi-minimal
     lookupPolicy:
       local: false
     tags:
     - annotations: null
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/ubi7/ubi:7.8
+        name: registry.access.redhat.com/ubi8/ubi-minimal:8.3
       importPolicy: {}
-      name: "7.8"
+      name: "8.3"
       referencePolicy:
         type: Source
     - annotations: null
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/ubi7/ubi:latest
+        name: registry.access.redhat.com/ubi8/ubi-minimal:latest
       importPolicy: {}
       name: latest
       referencePolicy:

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,8 +1,14 @@
-FROM registry.access.redhat.com/ubi7/ubi:7.8
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 ARG ERLANG_VERSION=22.1.4
 ARG RABBITMQ_AUTOCLUSTER_VERSION=0.10.0
 ARG RABBITMQ_VERSION=3.8.3
+
+ARG INSTALL_PKGS="\
+    hostname \
+    systemd \
+    tar \
+    xz"
 
 LABEL io.k8s.description="Lightweight open source message broker" \
     io.k8s.display-name="RabbitMQ" \
@@ -19,8 +25,9 @@ ENV GPG_KEY="0A9AF2115F4687BD29803A206B73A36E6026DFCA" \
     LC_ALL=en_US.UTF-8
 
 RUN set -xe && \
-    curl -LO https://github.com/rabbitmq/erlang-rpm/releases/download/v${ERLANG_VERSION}/erlang-${ERLANG_VERSION}-1.el7.x86_64.rpm && \
-    rpm -Uvh ./erlang-${ERLANG_VERSION}-1.el7.x86_64.rpm && \
+    microdnf install ${INSTALL_PKGS} && \
+    curl -LO https://github.com/rabbitmq/erlang-rpm/releases/download/v${ERLANG_VERSION}/erlang-${ERLANG_VERSION}-1.el8.x86_64.rpm && \
+    rpm -Uvh ./erlang-${ERLANG_VERSION}-1.el8.x86_64.rpm && \
     rm *.rpm && \
     curl -Lo rabbitmq-server.tar.xz https://github.com/rabbitmq/rabbitmq-server/releases/download/v${RABBITMQ_VERSION}/rabbitmq-server-generic-unix-${RABBITMQ_VERSION}.tar.xz && \
     curl -Lo rabbitmq-server.tar.xz.asc https://github.com/rabbitmq/rabbitmq-server/releases/download/v${RABBITMQ_VERSION}/rabbitmq-server-generic-unix-${RABBITMQ_VERSION}.tar.xz.asc && \
@@ -47,8 +54,6 @@ RUN set -xe && \
     chmod -R g=u /var/lib/rabbitmq /etc/rabbitmq && \
     rm -rf /var/lib/rabbitmq/.erlang.cookie && \
     ln -sf "$RABBITMQ_HOME/plugins" /plugins && \
-    INSTALL_PKGS="hostname" && \
-    yum install -y $INSTALL_PKGS && \
     rm -rf /var/cache/yum
 
 COPY docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
#### What is this PR About?
Use ubi-minimal:8.3 as base image for RabbitMQ

#### How do we test this?
```
./_test/rabbitmq applier rabbitmq-test pabrahamsson/containers-quickstarts rabbitmq_ubi_minimal-8
./_test/rabbitmq test rabbitmq-test pabrahamsson/containers-quickstarts rabbitmq_ubi_minimal-8
```

cc: @redhat-cop/day-in-the-life
