### PR TITLE
Update ubi-bats utility version + buildah & podman actions

### DIFF
--- a/.github/workflows/ubi8-bats-pr.yaml
+++ b/.github/workflows/ubi8-bats-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       context: utilities/ubi8-bats
       image_name: ubi8-bats
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Check and verify version.json
@@ -17,13 +17,15 @@ jobs:
           echo -n ::set-output name=IMAGE_TAGS::
           echo $(jq -r '.version' ${context}/version.json)
       - name: Build image
-        uses: docker/build-push-action@v1
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          push: false
-          repository: ${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          oci: true
           tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
       - name: Test image
         run: |
-          echo "Running: docker run -t -v $PWD:/code:z ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} /code/utilities/ubi8-bats/test"
-          docker run -t -v $PWD:/code:z ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} /code/utilities/ubi8-bats/test
+          echo "Running: podman run -t -v $PWD:/code:z ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} /code/utilities/ubi8-bats/test"
+          podman run -t -v $PWD:/code:z ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} /code/utilities/ubi8-bats/test

--- a/.github/workflows/ubi8-bats-publish.yaml
+++ b/.github/workflows/ubi8-bats-publish.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       context: utilities/ubi8-bats
       image_name: ubi8-bats
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags
@@ -27,13 +27,22 @@ jobs:
           if [[ "${GITHUB_REF}" =~ refs/tags/(.*) ]]; then
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
-          ( IFS=$','; echo "${TAGS[*]}" )
-      - name: Build and publish image to Quay
-        uses: docker/build-push-action@v1
+          echo "${TAGS[*]}"
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          registry: ${{ secrets.REGISTRY_URI }}
-          repository: ${{ secrets.REGISTRY_REPOSITORY }}/${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+      - name: Push to Quay
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+          tags: ${{ steps.build_image.outputs.tags }}

--- a/utilities/ubi8-bats/Dockerfile
+++ b/utilities/ubi8-bats/Dockerfile
@@ -3,15 +3,15 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 LABEL io.k8s.description="OCP Bats"
 LABEL io.k8s.display-name="OCP Bats"
 
-ARG BATS_VERSION=master
-ARG HELM_VERSION=3.2.1
+ARG BATS_VERSION=1.2.1
+ARG HELM_VERSION=3.5.2
 ARG JQ_VERSION=1.6
-ARG OC_VERSION=4.4
-ARG YQ_VERSION=3.3.0
+ARG OC_VERSION=4.7
+ARG YQ_VERSION=3.4.1
 
 RUN microdnf install -y gzip tar ncurses && \
     microdnf clean all && \
-    curl -L https://github.com/bats-core/bats-core/archive/${BATS_VERSION}.tar.gz | tar -C /tmp -xzf - && \
+    curl -L https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz | tar -C /tmp -xzf - && \
     /tmp/bats-core-${BATS_VERSION}/install.sh /opt/bats && \
     rm -rf /tmp/bats-core-${BATS_VERSION} && \
     ln -s /opt/bats/bin/bats /usr/local/bin/bats && \
@@ -20,7 +20,7 @@ RUN microdnf install -y gzip tar ncurses && \
     curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar --strip-components=1 -C /usr/local/bin -xzf - linux-amd64/helm && \
     curl -Lo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq && \
-    curl -L http://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz | tar -C /usr/local/bin -xzf - && \
+    curl -L http://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf - && \
     mkdir -p /code
 
 WORKDIR /code

--- a/utilities/ubi8-bats/buildah.sh
+++ b/utilities/ubi8-bats/buildah.sh
@@ -2,21 +2,21 @@
 
 set -o errexit
 
-BATS_VERSION=master
-HELM_VERSION=3.2.1
+BATS_VERSION=1.2.1
+HELM_VERSION=3.5.2
 JQ_VERSION=1.6
-OC_VERSION=4.4
-YQ_VERSION=3.3.0
+OC_VERSION=4.7
+YQ_VERSION=3.4.1
 
 container=$(buildah from registry.access.redhat.com/ubi8/ubi-minimal)
 buildah config --label io.k8s.description="OCP Bats" --label io.k8s.display-name="OCP Bats" $container
 buildah run $container -- bash -c 'microdnf install -y gzip tar ncurses && microdnf clean all'
-buildah run $container -- bash -c "curl -L https://github.com/bats-core/bats-core/archive/${BATS_VERSION}.tar.gz | tar -C /tmp -xzf - && /tmp/bats-core-${BATS_VERSION}/install.sh /opt/bats && rm -rf /tmp/bats-core-${BATS_VERSION} && ln -s /opt/bats/bin/bats /usr/local/bin/bats"
+buildah run $container -- bash -c "curl -L https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz | tar -C /tmp -xzf - && /tmp/bats-core-${BATS_VERSION}/install.sh /opt/bats && rm -rf /tmp/bats-core-${BATS_VERSION} && ln -s /opt/bats/bin/bats /usr/local/bin/bats"
 buildah run $container -- bash -c "curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 && chmod +x /usr/local/bin/jq"
 buildah run $container -- bash -c "curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar --strip-components=1 -C /usr/local/bin -xzf - linux-amd64/helm"
 buildah run $container -- bash -c "curl -Lo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 && chmod +x /usr/local/bin/yq"
-buildah run $container -- bash -c "curl -L http://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz | tar -C /usr/local/bin -xzf -"
+buildah run $container -- bash -c "curl -L http://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf -"
 buildah run $container -- mkdir -p /code
 buildah config --user 1001:0 --workingdir /code --entrypoint '["bats"]' $container
 
-buildah commit $container ubi-bats:latest
+buildah commit $container ubi8-bats:v${BATS_VERSION}

--- a/utilities/ubi8-bats/test/unit.bats
+++ b/utilities/ubi8-bats/test/unit.bats
@@ -3,13 +3,13 @@
 @test "bats: version" {
   run bats --version
   [ "${status}" -eq 0 ]
-  [ "${lines[0]}" = "Bats 1.2.0" ]
+  [ "${lines[0]}" = "Bats 1.2.1" ]
 }
 
 @test "helm: version" {
   run helm version
   [ "${status}" -eq 0 ]
-  [[ "${lines[0]}" =~ v3.2.1 ]]
+  [[ "${lines[0]}" =~ v3.5.2 ]]
 }
 
 @test "jq: version" {
@@ -21,11 +21,11 @@
 @test "oc: version" {
   run oc version
   [ "${status}" -eq 0 ]
-  [[ "${lines[0]}" =~ 4.4 ]]
+  [[ "${lines[0]}" =~ 4.7 ]]
 }
 
 @test "yq: version" {
   run yq --version
   [ "${status}" -eq 0 ]
-  [ "${lines[0]}" = "yq version 3.3.0" ]
+  [ "${lines[0]}" = "yq version 3.4.1" ]
 }

--- a/utilities/ubi8-bats/version.json
+++ b/utilities/ubi8-bats/version.json
@@ -1,1 +1,1 @@
-{"version":"v1.0"}
+{"version":"v1.2.1"}


### PR DESCRIPTION
#### What is this PR About?
Update versions of utilities and switch GH actions to use buildah and podman
>BATS_VERSION=1.2.1
HELM_VERSION=3.5.2
JQ_VERSION=1.6
OC_VERSION=4.7
YQ_VERSION=3.4.1

#### How do we test this?
GH Actions will do it

cc: @redhat-cop/day-in-the-life
