### PR TITLE
Enable prometheus scraping endpoint

### DIFF
--- a/_test/rabbitmq.sh
+++ b/_test/rabbitmq.sh
@@ -87,6 +87,15 @@ test() {
     exit 1
   fi
 
+  echo "Check prometheus endpoint..."
+  prom_code=$(oc -n $NAMESPACE exec rabbitmq-0 -- curl -so /dev/null -w %{http_code} localhost:15692/metrics)
+  if [ "${prom_code}" == "200" ]; then
+    echo "OK: Prometheus endpoint is up"
+  else
+    echo "NOK: Prometheus endpoint is not up"
+    exit 1
+  fi
+
   echo "Tests Completed Successfully!"
 }
 

--- a/rabbitmq/.openshift/templates/configmaps/config.yml
+++ b/rabbitmq/.openshift/templates/configmaps/config.yml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: rabbitmq-config
-data: 
+data:
   enabled_plugins: |
-      [rabbitmq_management,rabbitmq_peer_discovery_k8s].
-  policy.json: | 
+      [rabbitmq_management,rabbitmq_peer_discovery_k8s,rabbitmq_prometheus].
+  policy.json: |
       {
         "vhosts":[
           {
@@ -33,7 +33,7 @@ data:
           {
             "vhost": "/",
             "name": "ha-all",
-            "pattern": "", 
+            "pattern": "",
             "definition": {
               "ha-mode": "all",
               "ha-sync-mode": "automatic",

--- a/rabbitmq/.openshift/templates/deployments/template.yml
+++ b/rabbitmq/.openshift/templates/deployments/template.yml
@@ -39,6 +39,10 @@ objects:
       protocol: TCP
       port: 5672
       targetPort: 5672
+    - name: prometheus
+      protocol: TCP
+      port: 15692
+      targetPort: 15692
     selector:
       application: "${APPLICATION_NAME}"
     sessionAffinity: None
@@ -110,6 +114,9 @@ objects:
           - name: amqp
             protocol: TCP
             containerPort: 5672
+          - name: prometheus
+            protocol: TCP
+            containerPort: 15692
           readinessProbe:
             exec:
               # Learn more at https://www.rabbitmq.com/monitoring.html#health-checks.

--- a/rabbitmq/chart/templates/configmap.yaml
+++ b/rabbitmq/chart/templates/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rabbitmq-config
 data:
   enabled_plugins: |
-      [rabbitmq_management,rabbitmq_peer_discovery_k8s].
+      [rabbitmq_management,rabbitmq_peer_discovery_k8s,rabbitmq_prometheus].
   policy.json: |
       {
         "vhosts":[

--- a/rabbitmq/chart/templates/deployment.yaml
+++ b/rabbitmq/chart/templates/deployment.yaml
@@ -59,6 +59,9 @@ spec:
         - name: amqp
           protocol: TCP
           containerPort: 5672
+        - name: prometheus
+          protocol: TCP
+          containerPort: 15692
         securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
         readinessProbe:

--- a/rabbitmq/chart/values.yaml
+++ b/rabbitmq/chart/values.yaml
@@ -43,6 +43,10 @@ service:
       protocol: TCP
       port: 5672
       targetPort: 5672
+    - name: prometheus
+      protocol: TCP
+      port: 15692
+      targetPort: 15692
 
 ingress:
   enabled: false

--- a/rabbitmq/test/acceptance/rabbitmq.bats
+++ b/rabbitmq/test/acceptance/rabbitmq.bats
@@ -52,6 +52,11 @@ setup_file() {
   [ "${cluster_replicas}" == "3" ]
 }
 
+@test "rabbitmq/ha: should start prometheus endpoint" {
+  local prom_status=$(oc exec "$(name_prefix)-0" -- curl -so /dev/null -w %{http_code} localhost:15692/metrics)
+  [ "${prom_status}" == "200" ]
+}
+
 # Clean up
 teardown_file() {
   if [[ ${CLEANUP:-true} == "true" ]]

--- a/rabbitmq/test/unit/service.bats
+++ b/rabbitmq/test/unit/service.bats
@@ -18,11 +18,11 @@ load _helpers
 }
 
 # ports
-@test "service: two default ports" {
+@test "service: default ports" {
   cd $(chart_dir)
   local service_ports=$(helm template -s templates/service.yaml \
   . | yq r - --length 'spec.ports')
-  [ ${service_ports} -eq 2 ]
+  [ ${service_ports} -eq 3 ]
 }
 
 @test "service: default port names" {
@@ -35,6 +35,9 @@ load _helpers
 
   local amqp_port=$(echo "${service_ports}" | yq r - '[1].name')
   [ "${amqp_port}" == "amqp" ]
+
+  local prom_port=$(echo "${service_ports}" | yq r - '[2].name')
+  [ "${prom_port}" == "prometheus" ]
 }
 
 @test "service: custom port names" {
@@ -42,6 +45,7 @@ load _helpers
   local service_ports=$(helm template -s templates/service.yaml \
   --set 'service.ports[0].name=custom1' \
   --set 'service.ports[1].name=custom2' \
+  --set 'service.ports[2].name=custom3' \
   . | yq r - 'spec.ports')
 
   local port1=$(echo "${service_ports}" | yq r - '[0].name')
@@ -49,6 +53,9 @@ load _helpers
 
   local port2=$(echo "${service_ports}" | yq r - '[1].name')
   [ "${port2}" == "custom2" ]
+
+  local port3=$(echo "${service_ports}" | yq r - '[2].name')
+  [ "${port3}" == "custom3" ]
 }
 
 @test "service: default port numbers" {
@@ -61,6 +68,9 @@ load _helpers
 
   local amqp_port=$(echo "${service_ports}" | yq r - '[1].port')
   [ "${amqp_port}" == "5672" ]
+
+  local prom_port=$(echo "${service_ports}" | yq r - '[2].port')
+  [ "${prom_port}" == "15692" ]
 }
 
 @test "service: custom port numbers" {
@@ -68,6 +78,7 @@ load _helpers
   local service_ports=$(helm template -s templates/service.yaml \
   --set 'service.ports[0].port=1' \
   --set 'service.ports[1].port=2' \
+  --set 'service.ports[2].port=3' \
   . | yq r - 'spec.ports')
 
   local port1=$(echo "${service_ports}" | yq r - '[0].port')
@@ -75,6 +86,9 @@ load _helpers
 
   local port2=$(echo "${service_ports}" | yq r - '[1].port')
   [ "${port2}" == "2" ]
+
+  local port3=$(echo "${service_ports}" | yq r - '[2].port')
+  [ "${port3}" == "3" ]
 }
 
 # type


### PR DESCRIPTION
#### What is this PR About?
Enable RabbitMQ Prometheus metrics endpoint, needs #446 to be merged first

#### How do we test this?
This repo CI should test this but can also be tested manually
```
bats rabbitmq/test/unit rabbitmq/test/acceptance
```

cc: @redhat-cop/day-in-the-life
