### PR TITLE
build-s2i-python-kopf fix peering and example improvements

### DIFF
--- a/build-s2i-python-kopf/examples/kopf-simple/README.adoc
+++ b/build-s2i-python-kopf/examples/kopf-simple/README.adoc
@@ -86,7 +86,7 @@ odo delete kopf-simple
 
 == Building
 
-A Kustomize configuration for building this example in OpenShift is provided.
+OpenShift templates for building and deploying this example in OpenShift are provided.
 
 Create image stream and build config:
 

--- a/build-s2i-python-kopf/examples/kopf-simple/README.adoc
+++ b/build-s2i-python-kopf/examples/kopf-simple/README.adoc
@@ -20,27 +20,18 @@ odo create --devfile devfile.yaml
 
 Create role `kopf-simple`:
 
---------------------------------------------------------------------------------
+--------------------------
 oc apply -f rbac/role.yaml
---------------------------------------------------------------------------------
+--------------------------
 
 Grant `kopf-simple` role to default service account:
 
-----
-oc apply -f - <<EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: kopf-simple:serviceaccount:default
-subjects:
-- kind: ServiceAccount
-  name: default
-roleRef:
-  kind: Role
-  name: kopf-simple
-  apiGroup: rbac.authorization.k8s.io
-EOF
-----
+----------------------------------------
+oc policy add-role-to-user \
+--rolebinding-name=kopf-simple \
+--role-namespace=$(oc project --short) \
+kopf-simple -z default
+----------------------------------------
 
 Push code with `odo`:
 

--- a/build-s2i-python-kopf/examples/kopf-simple/operator/operator.py
+++ b/build-s2i-python-kopf/examples/kopf-simple/operator/operator.py
@@ -133,6 +133,11 @@ def manage_secret_for_config_map(name, namespace, config_map, logger):
         secret = create_secret(config, name, namespace, owner_reference, logger)
     update_config_map_status(name, namespace, config_map, secret)
 
+@kopf.on.startup()
+def configure(settings: kopf.OperatorSettings, **_):
+    # Disable scanning for Namespaces and CustomResourceDefinitions
+    settings.scanning.disabled = True
+
 @kopf.on.create('', 'v1', 'configmaps', labels={config_map_label: kopf.PRESENT})
 def on_create_config_map(body, name, namespace, logger, **_):
     logger.info("New app ConfigMap '%s'", name)

--- a/build-s2i-python-kopf/s2i/run
+++ b/build-s2i-python-kopf/s2i/run
@@ -46,7 +46,7 @@ fi
 if [[ "${KOPF_PEERING}" ]]; then
     KOPF_OPTIONS="${KOPF_OPTIONS} --peering=${KOPF_PEERING}"
     if [[ "${KOPF_NAMESPACE}" ]]; then
-        oc get kopfpeering anarchy ||  oc create -f - <<EOF
+        oc get kopfpeering.kopf.dev ${KOPF_PEERING} ||  oc create -f - <<EOF
 apiVersion: kopf.dev/v1
 kind: KopfPeering
 metadata:
@@ -54,7 +54,7 @@ metadata:
   name: $KOPF_PEERING
 EOF
     else
-        oc get kopfpeering anarchy ||  oc create -f - <<EOF
+        oc get clusterkopfpeering.kopf.dev ${KOPF_PEERING} ||  oc create -f - <<EOF
 apiVersion: kopf.dev/v1
 kind: ClusterKopfPeering
 metadata:


### PR DESCRIPTION
#### What is this PR About?

- Fix kopfclusterpeering existence check
- The oc commands to create kopfpeering resources should specify the kopf.dev domain
- Improvements to the python kopf simple example.

#### How do we test this?

Documented in the README

cc: @redhat-cop/day-in-the-life
