### PR TITLE
Fix kopf peering setup in s2i run

### DIFF
--- a/build-s2i-python-kopf/s2i/run
+++ b/build-s2i-python-kopf/s2i/run
@@ -46,7 +46,7 @@ fi
 if [[ "${KOPF_PEERING}" ]]; then
     KOPF_OPTIONS="${KOPF_OPTIONS} --peering=${KOPF_PEERING}"
     if [[ "${KOPF_NAMESPACE}" ]]; then
-        oc get kopfpeering anarchy ||  oc create -f - <<EOF
+        oc get kopfpeering.kopf.dev ${KOPF_PEERING} ||  oc create -f - <<EOF
 apiVersion: kopf.dev/v1
 kind: KopfPeering
 metadata:
@@ -54,7 +54,7 @@ metadata:
   name: $KOPF_PEERING
 EOF
     else
-        oc get kopfpeering anarchy ||  oc create -f - <<EOF
+        oc get clusterkopfpeering.kopf.dev ${KOPF_PEERING} ||  oc create -f - <<EOF
 apiVersion: kopf.dev/v1
 kind: ClusterKopfPeering
 metadata:


### PR DESCRIPTION
#### What is this PR About?

Fix KOPF_PEERING s2i run for Python Kopf builder image.

- Fix kopfclusterpeering existence check
- The `oc` commands to create kopfpeering resources should specify the kopf.dev domain

#### How do we test this?

See build-s2i-python-kopf/README.adoc

cc: @redhat-cop/day-in-the-life
