### PR TITLE
RabbitMQ migration to Bats & Helm for testing

### DIFF
--- a/rabbitmq/chart/templates/deployment.yaml
+++ b/rabbitmq/chart/templates/deployment.yaml
@@ -110,6 +110,8 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: mnesia
+      labels:
+        {{- include "chart.selectorLabels" . | nindent 8 }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/rabbitmq/test/acceptance/_helpers.bash
+++ b/rabbitmq/test/acceptance/_helpers.bash
@@ -6,6 +6,31 @@ chart_dir() {
   echo ${BATS_TEST_DIRNAME}/../../chart
 }
 
+# Create/Delete project
+project_action() {
+  ACTION=$1
+  PROJECT="rabbitmq-acceptance-${2}"
+
+  if [ "${ACTION}" == "create" ]; then
+    oc new-project ${PROJECT}
+  elif [ "${ACTION}" == "delete" ]; then
+    oc delete pod -l app.kubernetes.io/name=$(name_prefix) --ignore-not-found=true
+    oc delete pvc -l app.kubernetes.io/name=$(name_prefix) --ignore-not-found=true
+    oc delete project ${PROJECT}
+  fi
+}
+
+# If running inside a pod, authenticate to k8s/ocp
+ocp_auth() {
+  SA_PATH=/run/secrets/kubernetes.io/serviceaccount
+  if [[ -f ${SA_PATH}/token && -n "${OCP_AUTH}" ]]; then
+    export KUBECONFIG=/tmp/.kube/config
+    oc login --token $(cat ${SA_PATH}/token) \
+      --server https://kubernetes.default.svc \
+      --certificate-authority ${SA_PATH}/ca.crt
+  fi
+}
+
 # wait for a pod to be ready
 wait_for_running() {
     POD_NAME=$1

--- a/rabbitmq/test/acceptance/rabbitmq.bats
+++ b/rabbitmq/test/acceptance/rabbitmq.bats
@@ -4,12 +4,13 @@ JOB_ID=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 5 | head -1)
 
 load _helpers
 
+
 setup_file() {
+  ocp_auth
+
   cd $(chart_dir)
 
-  oc delete namespace rabbitmq-acceptance-${JOB_ID} --ignore-not-found=true
-  oc create namespace rabbitmq-acceptance-${JOB_ID}
-  oc config set-context --current --namespace rabbitmq-acceptance-${JOB_ID}
+  project_action create $JOB_ID
 
   helm install "$(name_prefix)" . --namespace rabbitmq-acceptance-${JOB_ID}
   wait_for_running $(name_prefix)-2
@@ -56,8 +57,9 @@ teardown_file() {
   if [[ ${CLEANUP:-true} == "true" ]]
   then
     echo "helm/pvc teardown"
-    helm delete "$(name_prefix)"
-    oc delete --all pvc
-    oc delete namespace rabbitmq-acceptance-${JOB_ID} --ignore-not-found=true
+    grace=$(oc get pod/rabbitmq-0 --template '{{.spec.terminationGracePeriodSeconds}}')
+    helm uninstall "$(name_prefix)"
+    sleep $grace
+    project_action delete $JOB_ID
   fi
 }


### PR DESCRIPTION
#### What is this PR About?
This is the first step in migrating from [openshift-applier](https://github.com/redhat-cop/openshift-applier) to Helm and Bats.

Bats will run unit tests against the included RabbitMQ Helm chart and then use the same chart do deploy a RabbitMQ cluster and run acceptance tests. 

#### How do we test this?
You'll need `oc`, `helm`, `yq` & `bats` and an OpenShift cluster where you can create namespaces/projects.
```
bats rabbitmq/test/unit rabbitmq/test/acceptance
```
cc: @redhat-cop/day-in-the-life
