### PR TITLE
RabbitMQ HA (anti affinity) fix

### DIFF
--- a/rabbitmq/chart/templates/_helpers.tpl
+++ b/rabbitmq/chart/templates/_helpers.tpl
@@ -61,3 +61,20 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create HA affinity rules
+*/}}
+{{- define "chart.enableHA" -}}
+{{- if .Values.ha.enabled -}}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+          - key: {{ .Values.ha.label.key }}
+            operator: In
+            values:
+              - {{ .Values.ha.label.value }}
+      topologyKey: {{ .Values.ha.topologyKey }}
+{{- end -}}
+{{- end -}}

--- a/rabbitmq/chart/templates/deployment.yaml
+++ b/rabbitmq/chart/templates/deployment.yaml
@@ -15,9 +15,9 @@ spec:
       labels:
         {{- include "chart.selectorLabels" . | nindent 8 }}
     spec:
-    {{- with .Values.affinity }}
+    {{- if .Values.ha.enabled }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- include "chart.enableHA" . | nindent 8 }}
     {{- end }}
       containers:
       - env:
@@ -49,8 +49,8 @@ spec:
             command: ["rabbitmq-diagnostics", "status"]
           initialDelaySeconds: 60
           # See https://www.rabbitmq.com/monitoring.html for monitoring frequency recommendations.
-          periodSeconds: 60
-          timeoutSeconds: 15
+          periodSeconds: 30
+          timeoutSeconds: 5
         name: {{ include "chart.fullname" . }}
         ports:
         - name: http
@@ -65,7 +65,7 @@ spec:
           exec:
             # Learn more at https://www.rabbitmq.com/monitoring.html#health-checks.
             command: ["rabbitmq-diagnostics", "check_port_connectivity"]
-          initialDelaySeconds: 20
+          initialDelaySeconds: 10
           periodSeconds: 60
           timeoutSeconds: 10
         resources:

--- a/rabbitmq/chart/values.yaml
+++ b/rabbitmq/chart/values.yaml
@@ -69,13 +69,9 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity:
-  podAntiAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-            - key: statefulset
-              operator: In
-              values:
-                - redhat-cop
-        topologyKey: kubernetes.io/hostname
+ha:
+  enabled: true
+  label:
+    key: app.kubernetes.io/name
+    value: rabbitmq
+  topologyKey: kubernetes.io/hostname

--- a/rabbitmq/test/unit/statefulset.bats
+++ b/rabbitmq/test/unit/statefulset.bats
@@ -142,22 +142,22 @@ load _helpers
 
   local match_key=$(echo "${affinity}" | yq r - \
   "${pod_anti_affinity}[0].labelSelector.matchExpressions[0].key")
-  [ "${match_key}" == "statefulset" ]
+  [ "${match_key}" == "app.kubernetes.io/name" ]
 
   local match_values=$(echo "${affinity}" | yq r - \
   "${pod_anti_affinity}[0].labelSelector.matchExpressions[0].values[0]")
-  [ "${match_values}" == "redhat-cop" ]
+  [ "${match_values}" == "$(name_prefix)" ]
 
   local topology_key=$(echo "${affinity}" | yq r - "${pod_anti_affinity}[0].topologyKey")
   [ "${topology_key}" == "kubernetes.io/hostname" ]
 }
 
-@test "statefulset: custom affinity" {
+@test "statefulset: custom affinity settings" {
   cd $(chart_dir)
   local affinity=$(helm template -s templates/deployment.yaml \
-  --set 'affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].key=statefulset' \
-  --set 'affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]=custom' \
-  --set 'affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey=kubernetes.io/instance' \
+  --set 'ha.label.key=statefulset' \
+  --set 'ha.label.value=custom' \
+  --set 'ha.topologyKey=kubernetes.io/instance' \
   . | yq r - 'spec.template.spec.affinity')
   [ -n "${affinity}" ]
 


### PR DESCRIPTION
#### What is this PR About?
The RabbitMQ Anti affinity settings were not using the correct label to match RabbitMQ pods.
Also refactor the HA (affinity) settings.

#### How do we test this?
This will be tested by the CI job
```
helm install rabbitmq rabbitmq/chart
bats rabbitmq/test/acceptance
```

cc: @redhat-cop/day-in-the-life
