### PR TITLE
Sonarqube: update to 7.9.6 + support updating plugins

### DIFF
--- a/sonarqube/.applier/group_vars/seed-hosts.yml
+++ b/sonarqube/.applier/group_vars/seed-hosts.yml
@@ -1,16 +1,18 @@
 namespace: sonarqube
 app_name: sonarqube
 jenkins_url: http://jenkins:80
-upstream_sq_version: 7.9.1-community
+upstream_sq_version: 7.9.6-community
 sonar_search_java_additional_opts: '-Dnode.store.allow_mmapfs=false'
+build_repo: https://github.com/redhat-cop/containers-quickstarts.git
+build_ref: master
 
 build:
   FROM_DOCKER_IMAGE: "{{ app_name }}"
   FROM_DOCKER_IMAGE_REGISTRY_URL: docker.io/sonarqube
   FROM_DOCKER_TAG: "{{ upstream_sq_version }}"
   NAME: "{{ app_name }}"
-  SOURCE_REPOSITORY_URL: https://github.com/redhat-cop/containers-quickstarts.git
-  SOURCE_REPOSITORY_REF: master
+  SOURCE_REPOSITORY_URL: "{{ build_repo }}"
+  SOURCE_REPOSITORY_REF: "{{ build_ref }}"
   SOURCE_CONTEXT_DIR: "{{ app_name }}"
 postgresql:
   DATABASE_SERVICE_NAME: sonardb

--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/sonarqube:latest
 USER root
 
 CMD apk update && apk add curl
-ARG sonar_plugins="pmd ldap"
+ARG sonar_plugins="java pmd ldap"
 ADD sonar.properties /opt/sonarqube/conf/sonar.properties
 ADD run.sh /opt/sonarqube/bin/run.sh
 CMD /opt/sonarqube/bin/run.sh

--- a/sonarqube/plugins.sh
+++ b/sonarqube/plugins.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-# set -x	## Uncomment for debugging
+# set -x  ## Uncomment for debugging
 
 printf 'Downloading plugin details\n'
 
@@ -14,24 +14,34 @@ curl -L -sS -o /tmp/pluginList.txt https://update.sonarsource.org/update-center.
 printf "Downloading additional plugins\n"
 for PLUGIN in "$@"
 do
-	printf '\tExtracting plugin download location - %s\n' ${PLUGIN}
-	MATCH_STRING=$(cat /tmp/pluginList.txt | grep requiredSonarVersions | grep -E "[,=]${SQ_VERSION}(,|$)" | sed 's@\.requiredSonarVersions.*@@g' | sort -V | grep "^${PLUGIN}\." | tail -n 1 | sed 's@$@.downloadUrl@g')
+  printf '\tExtracting plugin download location - %s\n' ${PLUGIN}
+  MATCH_STRING=$(cat /tmp/pluginList.txt | grep requiredSonarVersions | grep -E "[,=]${SQ_VERSION}(,|$)" | sed 's@\.requiredSonarVersions.*@@g' | sort -V | grep "^${PLUGIN}\." | tail -n 1 | sed 's@$@.downloadUrl@g')
 
-	if ! [[ -z "${MATCH_STRING}" ]]; then
-		DOWNLOAD_URL=$(cat /tmp/pluginList.txt | grep ${MATCH_STRING} | awk -F"=" '{print $2}' | sed 's@\\:@:@g')
-		PLUGIN_FILE=$(echo ${DOWNLOAD_URL} | sed 's@.*/\(.*\)$@\1@g')
+  if ! [[ -z "${MATCH_STRING}" ]]; then
+    DOWNLOAD_URL=$(cat /tmp/pluginList.txt | grep ${MATCH_STRING} | awk -F"=" '{print $2}' | sed 's@\\:@:@g')
+    PLUGIN_FILE=$(echo ${DOWNLOAD_URL} | sed 's@.*/\(.*\)$@\1@g')
+    BASENAME=$(echo ${PLUGIN_FILE} | sed 's/-[0-9].*//')
 
-		## Check to see if plugin exists, attempt to download the plugin if it does exist.
-		if ! [[ -z "${DOWNLOAD_URL}" ]]; then
-			curl -L -sS -o /opt/sonarqube/extensions-init/plugins/${PLUGIN_FILE} ${DOWNLOAD_URL} && printf "\t\t%-35s%10s" "${PLUGIN_FILE}" "DONE" || printf "\t\t%-35s%10s" "${PLUGIN_FILE}" "FAILED"
-			printf "\n"
-		else
-			## Plugin was not found in the plugin inventory
-			printf "\t\t%-15s%10s\n" "${PLUGIN}" "NOT FOUND"
-		fi
-	else
-		printf "\t\t%-15s%10s\n" $PLUGIN "NOT FOUND"
-	fi
+    ## Check to see if plugin exists, attempt to download the plugin if it does exist.
+    if ! [[ -z "${DOWNLOAD_URL}" ]]; then
+      RC=$(curl -L -sS -w %{http_code} -o /opt/sonarqube/extensions-init/plugins/${PLUGIN_FILE} ${DOWNLOAD_URL})
+      if [[ "${RC}" == "200" ]]; then
+        printf "\t\t%-35s%10s\n" "${PLUGIN_FILE}" "DONE"
+        for f in /opt/sonarqube/extensions-init/plugins/${BASENAME}*.jar; do
+          if [[ "${f}" != "/opt/sonarqube/extensions-init/plugins/${PLUGIN_FILE}" ]]; then
+            rm -vf $f
+          fi
+        done
+      else
+        printf "\t\t%-35s%10s\n" "${PLUGIN_FILE}" "FAILED"
+      fi
+    else
+      ## Plugin was not found in the plugin inventory
+      printf "\t\t%-15s%10s\n" "${PLUGIN}" "NOT FOUND"
+    fi
+  else
+    printf "\t\t%-15s%10s\n" $PLUGIN "NOT FOUND"
+  fi
 done
 
 rm -f /tmp/pluginList.txt


### PR DESCRIPTION
#### What is this PR About?
Update Sonarqube to `7.9.6` and add support for updating existing plugins.
This is needed because the `pmd` plugin requires a newer version of the `java` plugin.

#### How do we test this?
```bash
ansible-galaxy install -r requirements.txt -p galaxy
ansible-playbook -i .applier galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e build_repo='https://github.com/pabrahamsson/containers-quickstarts.git' -e build_ref=sq_java_plugin
```
There should not be any errors in sonarqube about `pmd` needing a newer version of the `java` plugin.

cc: @redhat-cop/day-in-the-life
