### PR TITLE
Update GH actions to use redhat-actions for build & publish

### DIFF
--- a/.github/workflows/build-s2i-python-kopf-pr.yaml
+++ b/.github/workflows/build-s2i-python-kopf-pr.yaml
@@ -9,7 +9,7 @@ jobs:
     env:
       CONTEXT_DIR: build-s2i-python-kopf
       IMAGE_NAME: python-kopf-s2i
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Check and verify version.json
@@ -25,18 +25,22 @@ jobs:
           echo ::set-output name=MINOR_VERSION::${VERSION%.*}
           sed -i -e "s/^FROM .*/FROM ${IMAGE_NAME}:${VERSION}/" ${CONTEXT_DIR}/examples/kopf-simple/Dockerfile
       - name: Build s2i image
-        uses: docker/build-push-action@v1
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.CONTEXT_DIR }}
-          push: false
-          repository: ${{ env.IMAGE_NAME }}
+          context: ${{ env.CONTEXT_DIR }}
+          dockerfiles: |
+            ./${{ env.CONTEXT_DIR }}/Dockerfile
+          image: ${{ env.IMAGE_NAME }}
+          oci: true
           tags: ${{ steps.check_version.outputs.VERSION }}
       - name: Build kopf-simple example from s2i image
-        uses: docker/build-push-action@v1
+        uses: docker/buildah-build@v2
         with:
-          path: ${{ env.CONTEXT_DIR }}/examples/kopf-simple
-          push: false
-          repository: ${{ env.IMAGE_NAME }}-example
+          context: ${{ env.CONTEXT_DIR }}/examples/kopf-simple
+          dockerfiles: |
+            ./${{ env.CONTEXT_DIR }}/examples/kopf-simple
+          image: ${{ env.IMAGE_NAME }}-example
+          oci: true
           tags: ${{ steps.check_version.outputs.VERSION }}
       - name: Test image
         run: |
@@ -49,7 +53,7 @@ jobs:
           fi
 
           echo "Checking example operator.py..."
-          docker run --entrypoint '/bin/sh' $EXAMPLE_IMAGE -c 'python3 -m py_compile /opt/app-root/operator/operator.py'
+          podman run --entrypoint '/bin/sh' $EXAMPLE_IMAGE -c 'python3 -m py_compile /opt/app-root/operator/operator.py'
 
           echo "Check example requirements were installed..."
-          docker run --entrypoint '/bin/sh' $EXAMPLE_IMAGE -c 'python3 -c "import yaml"'
+          podman run --entrypoint '/bin/sh' $EXAMPLE_IMAGE -c 'python3 -c "import yaml"'

--- a/.github/workflows/build-s2i-python-kopf-publish.yaml
+++ b/.github/workflows/build-s2i-python-kopf-publish.yaml
@@ -11,7 +11,7 @@ jobs:
     env:
       CONTEXT_DIR: build-s2i-python-kopf
       IMAGE_NAME: python-kopf-s2i
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags
@@ -23,12 +23,21 @@ jobs:
           TAGS=('latest' "${VERSION}" "${VERSION%.*}")
           # Set IMAGE_TAGS output for use in next step
           ( IFS=$','; echo "::set-output name=IMAGE_TAGS::${TAGS[*]}" )
-      - name: Build and publish image to Quay
-        uses: docker/build-push-action@v1
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.CONTEXT_DIR }}
-          registry: ${{ secrets.REGISTRY_URI }}
-          repository: ${{ secrets.REGISTRY_REPOSITORY }}/${{ env.IMAGE_NAME }}
+          context: ${{ env.CONTEXT_DIR }}
+          dockerfiles: |
+            ./${{ env.CONTEXT_DIR }}/Dockerfile
+          image: ${{ env.IMAGE_NAME }}
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+      - name: Push to Quay
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+          tags: ${{ steps.build_image.outputs.tags }}

--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   conftest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/github-runner-ubi8.yaml
+++ b/.github/workflows/github-runner-ubi8.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       CONTEXT_DIR: github-runner-ubi8
       IMAGE_NAME: github-runner-ubi8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags

--- a/.github/workflows/jenkins-agent-image-mgmt-pr.yaml
+++ b/.github/workflows/jenkins-agent-image-mgmt-pr.yaml
@@ -8,22 +8,24 @@ jobs:
     env:
       context: jenkins-agents/jenkins-agent-image-mgmt
       image_name: jenkins-agent-image-mgmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
       - name: Check and verify version.json
+        uses: actions/checkout@v1
         id: check_version
         run: |
           echo -n ::set-output name=IMAGE_TAGS::
           echo $(jq -r '.version' ${context}/version.json)
       - name: Build image
-        uses: docker/build-push-action@v1
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          push: false
-          repository: ${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          oci: true
           tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
       - name: Test image
         run: |
-          echo "Running: docker run --entrypoint bash ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} -c \"skopeo --version\""
-          docker run --entrypoint bash ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} -c "skopeo --version"
+          echo "Running: podman run --entrypoint bash ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} -c \"skopeo --version\""
+          podman run --entrypoint bash ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} -c "skopeo --version"

--- a/.github/workflows/jenkins-agent-image-mgmt-publish.yaml
+++ b/.github/workflows/jenkins-agent-image-mgmt-publish.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       context: jenkins-agents/jenkins-agent-image-mgmt
       image_name: jenkins-agent-image-mgmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags
@@ -28,12 +28,21 @@ jobs:
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
           ( IFS=$','; echo "${TAGS[*]}" )
-      - name: Build and publish image to Quay
-        uses: docker/build-push-action@v1
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          registry: ${{ secrets.REGISTRY_URI }}
-          repository: ${{ secrets.REGISTRY_REPOSITORY }}/${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+      - name: Push to Quay
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+          tags: ${{ steps.build_image.outputs.tags }}

--- a/.github/workflows/jenkins-agent-python-pr.yaml
+++ b/.github/workflows/jenkins-agent-python-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       context: jenkins-agents/jenkins-agent-python
       image_name: jenkins-agent-python
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Check and verify version.json
@@ -17,15 +17,17 @@ jobs:
           echo -n ::set-output name=IMAGE_TAGS::
           echo $(jq -r '.version' ${context}/version.json)
       - name: Build image
-        uses: docker/build-push-action@v1
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          push: false
-          repository: ${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          oci: true
           tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
       - name: Test image
         run: |
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} python --version"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} python --version
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pip --version"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pip --version
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} python --version"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} python --version
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pip --version"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pip --version

--- a/.github/workflows/jenkins-agent-python-publish.yaml
+++ b/.github/workflows/jenkins-agent-python-publish.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       context: jenkins-agents/jenkins-agent-python
       image_name: jenkins-agent-python
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags
@@ -28,12 +28,21 @@ jobs:
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
           ( IFS=$','; echo "${TAGS[*]}" )
-      - name: Build and publish image to Quay
-        uses: docker/build-push-action@v1
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          registry: ${{ secrets.REGISTRY_URI }}
-          repository: ${{ secrets.REGISTRY_REPOSITORY }}/${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+      - name: Push to Quay
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+          tags: ${{ steps.build_image.outputs.tags }}

--- a/.github/workflows/rabbitmq-pr.yaml
+++ b/.github/workflows/rabbitmq-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       context: rabbitmq
       image_name: rabbitmq
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Check and verify version.json
@@ -17,13 +17,15 @@ jobs:
           echo -n ::set-output name=IMAGE_TAGS::
           echo $(jq -r '.version' ${context}/version.json)
       - name: Build image
-        uses: docker/build-push-action@v1
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          push: false
-          repository: ${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          oci: true
           tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
       - name: Test image
         run: |
-          echo "Running: docker run --entrypoint 'rabbitmqctl' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} 'version'"
-          docker run --entrypoint 'rabbitmqctl' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} 'version'
+          echo "Running: podman run --entrypoint 'rabbitmqctl' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} 'version'"
+          podman run --entrypoint 'rabbitmqctl' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} 'version'

--- a/.github/workflows/rabbitmq-publish.yaml
+++ b/.github/workflows/rabbitmq-publish.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       context: rabbitmq
       image_name: rabbitmq
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags
@@ -28,12 +28,21 @@ jobs:
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
           ( IFS=$','; echo "${TAGS[*]}" )
-      - name: Build and publish image to Quay
-        uses: docker/build-push-action@v1
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          registry: ${{ secrets.REGISTRY_URI }}
-          repository: ${{ secrets.REGISTRY_REPOSITORY }}/${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+      - name: Push to Quay
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+          tags: ${{ steps.build_image.outputs.tags }}

--- a/.github/workflows/tekton-task-images-conftest-pr.yaml
+++ b/.github/workflows/tekton-task-images-conftest-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       context: tekton-task-images/conftest
       image_name: conftest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Get image tags
@@ -19,13 +19,14 @@ jobs:
           source ${context}/VERSION
           echo ${CONFTEST_VERSION}
       - name: Build image
-        uses: docker/build-push-action@v1
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          push: false
-          repository: ${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          oci: true
           tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
-      - name: Test image contains the version of the binary
         run: |
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} conftest version"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} conftest --version | grep ${{ steps.check_version.outputs.IMAGE_TAGS }}
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} conftest version"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} conftest --version | grep ${{ steps.check_version.outputs.IMAGE_TAGS }}

--- a/.github/workflows/tekton-task-images-conftest-publish.yaml
+++ b/.github/workflows/tekton-task-images-conftest-publish.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       context: tekton-task-images/conftest
       image_name: conftest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags
@@ -26,12 +26,21 @@ jobs:
               TAGS+=("${CONFTEST_VERSION}")
           fi
           ( IFS=$','; echo "${TAGS[*]}" )
-      - name: Build and publish image to Quay
-        uses: docker/build-push-action@v1
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          registry: ${{ secrets.REGISTRY_URI }}
-          repository: ${{ secrets.REGISTRY_REPOSITORY }}/${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+      - name: Push to Quay
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+          tags: ${{ steps.build_image.outputs.tags }}

--- a/.github/workflows/tekton-task-images-helm-pr.yaml
+++ b/.github/workflows/tekton-task-images-helm-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       context: tekton-task-images/helm
       image_name: helm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Get image tags
@@ -19,13 +19,15 @@ jobs:
           source ${context}/VERSION
           echo ${HELM_VERSION}
       - name: Build image
-        uses: docker/build-push-action@v1
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          push: false
-          repository: ${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          oci: true
           tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
       - name: Test image contains the version of the binary
         run: |
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} helm version"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} helm version | grep ${{ steps.check_version.outputs.IMAGE_TAGS }}
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} helm version"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} helm version | grep ${{ steps.check_version.outputs.IMAGE_TAGS }}

--- a/.github/workflows/tekton-task-images-helm-publish.yaml
+++ b/.github/workflows/tekton-task-images-helm-publish.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       context: tekton-task-images/helm
       image_name: helm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags
@@ -26,12 +26,21 @@ jobs:
               TAGS+=("${HELM_VERSION}")
           fi
           ( IFS=$','; echo "${TAGS[*]}" )
-      - name: Build and publish image to Quay
-        uses: docker/build-push-action@v1
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          registry: ${{ secrets.REGISTRY_URI }}
-          repository: ${{ secrets.REGISTRY_REPOSITORY }}/${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+      - name: Push to Quay
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+          tags: ${{ steps.build_image.outputs.tags }}

--- a/.github/workflows/ubi7-gitlab-runner-pr.yaml
+++ b/.github/workflows/ubi7-gitlab-runner-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       context: ubi7-gitlab-runner
       image_name: ubi7-gitlab-runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Check and verify version.json
@@ -17,15 +17,17 @@ jobs:
           echo -n ::set-output name=IMAGE_TAGS::
           echo $(jq -r '.version' ${context}/version.json)
       - name: Build image
-        uses: docker/build-push-action@v1
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          push: false
-          repository: ${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          oci: true
           tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
       - name: Test image
         run: |
-          echo "Running: docker run --entrypoint '/bin/sh' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} -c 'wget --version'"
-          docker run --entrypoint '/bin/sh' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} -c 'wget --version'
-          echo "Running: docker run --entrypoint '/bin/sh' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} -c 'gitlab-runner --version'"
-          docker run --entrypoint '/bin/sh' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} -c 'gitlab-runner --version'
+          echo "Running: podman run --entrypoint '/bin/sh' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} -c 'wget --version'"
+          podman run --entrypoint '/bin/sh' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} -c 'wget --version'
+          echo "Running: podman run --entrypoint '/bin/sh' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} -c 'gitlab-runner --version'"
+          podman run --entrypoint '/bin/sh' ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} -c 'gitlab-runner --version'

--- a/.github/workflows/ubi7-gitlab-runner-publish.yaml
+++ b/.github/workflows/ubi7-gitlab-runner-publish.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       context: ubi7-gitlab-runner
       image_name: ubi7-gitlab-runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags
@@ -28,12 +28,21 @@ jobs:
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
           ( IFS=$','; echo "${TAGS[*]}" )
-      - name: Build and publish image to Quay
-        uses: docker/build-push-action@v1
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          registry: ${{ secrets.REGISTRY_URI }}
-          repository: ${{ secrets.REGISTRY_REPOSITORY }}/${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+      - name: Push to Quay
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+          tags: ${{ steps.build_image.outputs.tags }}

--- a/.github/workflows/ubi8-asciidoctor-pr.yaml
+++ b/.github/workflows/ubi8-asciidoctor-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       context: utilities/ubi8-asciidoctor
       image_name: ubi8-asciidoctor
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Check and verify version.json
@@ -17,19 +17,21 @@ jobs:
           echo -n ::set-output name=IMAGE_TAGS::
           echo $(jq -r '.version' ${context}/version.json)
       - name: Build image
-        uses: docker/build-push-action@v1
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          push: false
-          repository: ${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          oci: true
           tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
       - name: Test image
         run: |
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} git --version"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} git --version
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} asciidoctor --version"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} asciidoctor --version
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} asciidoctor-pdf --version"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} asciidoctor-pdf --version
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pandoc --version"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pandoc --version
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} git --version"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} git --version
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} asciidoctor --version"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} asciidoctor --version
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} asciidoctor-pdf --version"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} asciidoctor-pdf --version
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pandoc --version"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pandoc --version

--- a/.github/workflows/ubi8-asciidoctor-publish.yaml
+++ b/.github/workflows/ubi8-asciidoctor-publish.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       context: utilities/ubi8-asciidoctor
       image_name: ubi8-asciidoctor
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags
@@ -28,12 +28,21 @@ jobs:
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
           ( IFS=$','; echo "${TAGS[*]}" )
-      - name: Build and publish image to Quay
-        uses: docker/build-push-action@v1
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          registry: ${{ secrets.REGISTRY_URI }}
-          repository: ${{ secrets.REGISTRY_REPOSITORY }}/${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+      - name: Push to Quay
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+          tags: ${{ steps.build_image.outputs.tags }}

--- a/.github/workflows/ubi8-git-pr.yaml
+++ b/.github/workflows/ubi8-git-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       context: utilities/ubi8-git
       image_name: ubi8-git
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Check and verify version.json
@@ -17,13 +17,15 @@ jobs:
           echo -n ::set-output name=IMAGE_TAGS::
           echo $(jq -r '.version' ${context}/version.json)
       - name: Build image
-        uses: docker/build-push-action@v1
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          push: false
-          repository: ${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          oci: true
           tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
       - name: Test image
         run: |
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} git --version"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} git --version
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} git --version"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} git --version

--- a/.github/workflows/ubi8-git-publish.yaml
+++ b/.github/workflows/ubi8-git-publish.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       context: utilities/ubi8-git
       image_name: ubi8-git
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags
@@ -28,12 +28,21 @@ jobs:
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
           ( IFS=$','; echo "${TAGS[*]}" )
-      - name: Build and publish image to Quay
-        uses: docker/build-push-action@v1
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          registry: ${{ secrets.REGISTRY_URI }}
-          repository: ${{ secrets.REGISTRY_REPOSITORY }}/${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+      - name: Push to Quay
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+          tags: ${{ steps.build_image.outputs.tags }}

--- a/.github/workflows/ubi8-google-api-python-client-pr.yaml
+++ b/.github/workflows/ubi8-google-api-python-client-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       context: utilities/ubi8-google-api-python-client
       image_name: ubi8-google-api-python-client
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Check and verify version.json
@@ -17,19 +17,21 @@ jobs:
           echo -n ::set-output name=IMAGE_TAGS::
           echo $(jq -r '.version' ${context}/version.json)
       - name: Build image
-        uses: docker/build-push-action@v1
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          push: false
-          repository: ${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          oci: true
           tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
       - name: Test image
         run: |
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} git --version"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} git --version
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pip3 --version"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pip3 --version
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pip3 show google-api-python-client google-auth-httplib2 google-auth-oauthlib"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pip3 show google-api-python-client google-auth-httplib2 google-auth-oauthlib
-          echo "Running: docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} upload-file-to-google-drive --help"
-          docker run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} upload-file-to-google-drive --help
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} git --version"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} git --version
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pip3 --version"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pip3 --version
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pip3 show google-api-python-client google-auth-httplib2 google-auth-oauthlib"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} pip3 show google-api-python-client google-auth-httplib2 google-auth-oauthlib
+          echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} upload-file-to-google-drive --help"
+          podman run ${image_name}:${{ steps.check_version.outputs.IMAGE_TAGS }} upload-file-to-google-drive --help

--- a/.github/workflows/ubi8-google-api-python-client-publish.yaml
+++ b/.github/workflows/ubi8-google-api-python-client-publish.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       context: utilities/ubi8-google-api-python-client
       image_name: ubi8-google-api-python-client
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags
@@ -28,12 +28,21 @@ jobs:
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
           ( IFS=$','; echo "${TAGS[*]}" )
-      - name: Build and publish image to Quay
-        uses: docker/build-push-action@v1
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.context }}
-          registry: ${{ secrets.REGISTRY_URI }}
-          repository: ${{ secrets.REGISTRY_REPOSITORY }}/${{ env.image_name }}
+          context: ${{ env.context }}
+          dockerfiles: |
+            ./${{ env.context }}/Dockerfile
+          image: ${{ env.image_name }}
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+      - name: Push to Quay
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+          tags: ${{ steps.build_image.outputs.tags }}


### PR DESCRIPTION
#### What is this PR About?
`docker/build-and-push@v1` has been deprecated so this seemed like a good time to switch to using `redhat-actions/buildah-build@v2` and `redhat-actions/push-to-registry@v2`.
These actions are already being used by `ubi8-bats`.

#### How do we test this?
Should be handled by the CI for this repo

cc: @redhat-cop/day-in-the-life
