### PR TITLE
🐧 ADD conftest to helm agent and UPDATE versions 🐧

### DIFF
--- a/jenkins-agents/jenkins-agent-conftest/README.md
+++ b/jenkins-agents/jenkins-agent-conftest/README.md
@@ -4,6 +4,7 @@ This agent extends the base jenkins agent image and adds the following binaries 
  - [conftest](https://conftest.dev/) 
  - [yq](https://pypi.org/project/yq/)
  - [bats](https://github.com/bats-core/bats-core)
+ - [helm](https://github.com/bats-core/bats-core)
 
 ## Build in OpenShift
 ```bash

--- a/jenkins-agents/jenkins-agent-conftest/README.md
+++ b/jenkins-agents/jenkins-agent-conftest/README.md
@@ -4,13 +4,12 @@ This agent extends the base jenkins agent image and adds the following binaries 
  - [conftest](https://conftest.dev/) 
  - [yq](https://pypi.org/project/yq/)
  - [bats](https://github.com/bats-core/bats-core)
- - [helm](https://github.com/bats-core/bats-core)
 
 ## Build in OpenShift
 ```bash
 oc process -f ../../.openshift/templates/jenkins-agent-generic-template.yml \
-    -p NAME=jenkins-agent-rego \
-    -p SOURCE_CONTEXT_DIR=jenkins-agents/jenkins-agent-rego \
+    -p NAME=jenkins-agent-conftest \
+    -p SOURCE_CONTEXT_DIR=jenkins-agents/jenkins-agent-conftest \
     -p DOCKERFILE_PATH=Dockerfile \
     | oc create -n openshift -f -
 ```

--- a/jenkins-agents/jenkins-agent-helm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-helm/Dockerfile
@@ -1,21 +1,24 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.6
+FROM quay.io/openshift/origin-jenkins-agent-base:4.7
 
-ARG VERSION=3.2.0
+ARG VERSION=3.5.2
 ARG YQ_VERSION=v4.5.1
-ARG CT_VERSION=3.0.0-rc.1
-ARG OPENSHIFT_CLIENT_VERSION=4.4.13
+ARG CT_VERSION=3.3.1
+ARG OPENSHIFT_CLIENT_VERSION=4.7.5
+ARG CONFTEST_VERSION=0.23.0
 
 ## Required in order to avoid ct "ascii codec can't encode character" error
 ENV PYTHONIOENCODING=utf-8
 
 COPY ubi8.repo /tmp/
 
-## Install helm and yq
-RUN curl -skL -o /tmp/helm.tar.gz https://get.helm.sh/helm-v${VERSION}-linux-amd64.tar.gz && \ 
+## Install helm and yq and conftest
+RUN curl -skL -o /tmp/helm.tar.gz https://get.helm.sh/helm-v${VERSION}-linux-amd64.tar.gz && \
+    curl -skL -o /tmp/conftest.tar.gz https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz && \
     tar -C /tmp -xzf /tmp/helm.tar.gz && \
-    mv /tmp/linux-amd64/helm /usr/local/bin && \
-    chmod -R 775 /usr/local/bin/helm && \
-    rm -rf /tmp/helm.tar.gz && \
+    tar -C /tmp -xzf /tmp/conftest.tar.gz && \
+    mv -v /tmp/linux-amd64/helm /tmp/conftest /usr/local/bin && \
+    chmod -R 775 /usr/local/bin/helm /usr/local/bin/conftest && \
+    rm -rf /tmp/*.tar.gz && \
     rm -rf /tmp/linux-amd64 && \
     curl -sL  https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -o /usr/local/bin/yq && \
     chmod -R 775 /usr/local/bin/yq

--- a/jenkins-agents/jenkins-agent-helm/Jenkinsfile.test
+++ b/jenkins-agents/jenkins-agent-helm/Jenkinsfile.test
@@ -14,6 +14,7 @@ pipeline {
                   python --version
                   oc version
                   kubectl version
+                  conftest --version
               """
             }
         }


### PR DESCRIPTION
#### What is this PR About?
Bounced some versions and added conftest binary to this image. Reason I've added it is as in my pipeline i want to `helm template my chart --output-dir policy/helm-output` and run some policy checks on the generated template artifacts. Having the conftest binary and helm ones in separate agents is time wasted waiting for Jenkins to fire up another agent. 

 
#### How do we test this?
let ci do it's thing? you could also docker build or follow the readme's instructions 🤷‍♀️

cc: @redhat-cop/day-in-the-life
