### PR TITLE
GH buildah-build action needs space separated tags

### DIFF
--- a/.github/workflows/build-s2i-python-kopf-publish.yaml
+++ b/.github/workflows/build-s2i-python-kopf-publish.yaml
@@ -23,7 +23,7 @@ jobs:
           # Publish to latest, minor, and patch tags
           TAGS=('latest' "${VERSION}" "${VERSION%.*}")
           # Set IMAGE_TAGS output for use in next step
-          ( IFS=$','; echo "::set-output name=IMAGE_TAGS::${TAGS[*]}" )
+          echo "::set-output name=IMAGE_TAGS::${TAGS[*]}"
       - name: Build image
         id: build_image
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/jenkins-agent-image-mgmt-publish.yaml
+++ b/.github/workflows/jenkins-agent-image-mgmt-publish.yaml
@@ -28,7 +28,7 @@ jobs:
           if [[ "${GITHUB_REF}" =~ refs/tags/(.*) ]]; then
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
-          ( IFS=$','; echo "${TAGS[*]}" )
+          echo "${TAGS[*]}"
       - name: Build image
         id: build_image
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/jenkins-agent-python-publish.yaml
+++ b/.github/workflows/jenkins-agent-python-publish.yaml
@@ -28,7 +28,7 @@ jobs:
           if [[ "${GITHUB_REF}" =~ refs/tags/(.*) ]]; then
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
-          ( IFS=$','; echo "${TAGS[*]}" )
+          echo "${TAGS[*]}"
       - name: Build image
         id: build_image
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/rabbitmq-publish.yaml
+++ b/.github/workflows/rabbitmq-publish.yaml
@@ -28,7 +28,7 @@ jobs:
           if [[ "${GITHUB_REF}" =~ refs/tags/(.*) ]]; then
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
-          ( IFS=$','; echo "${TAGS[*]}" )
+          echo "${TAGS[*]}"
       - name: Build image
         id: build_image
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/tekton-task-images-conftest-publish.yaml
+++ b/.github/workflows/tekton-task-images-conftest-publish.yaml
@@ -22,11 +22,10 @@ jobs:
           echo -n ::set-output name=IMAGE_TAGS::
            # exposes variable CONFTEST_VERSION
           source ${context}/VERSION
-          TAGS=('latest')
-          if [ "${CONFTEST_VERSION}" ] && [ "${CONFTEST_VERSION}" != "latest" ]; then
+          TAGS=('latest') if [ "${CONFTEST_VERSION}" ] && [ "${CONFTEST_VERSION}" != "latest" ]; then
               TAGS+=("${CONFTEST_VERSION}")
           fi
-          ( IFS=$','; echo "${TAGS[*]}" )
+          echo "${TAGS[*]}"
       - name: Build image
         id: build_image
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/tekton-task-images-helm-publish.yaml
+++ b/.github/workflows/tekton-task-images-helm-publish.yaml
@@ -26,7 +26,7 @@ jobs:
           if [ "${HELM_VERSION}" ] && [ "${HELM_VERSION}" != "latest" ]; then
               TAGS+=("${HELM_VERSION}")
           fi
-          ( IFS=$','; echo "${TAGS[*]}" )
+          echo "${TAGS[*]}"
       - name: Build image
         id: build_image
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/ubi7-gitlab-runner-publish.yaml
+++ b/.github/workflows/ubi7-gitlab-runner-publish.yaml
@@ -28,7 +28,7 @@ jobs:
           if [[ "${GITHUB_REF}" =~ refs/tags/(.*) ]]; then
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
-          ( IFS=$','; echo "${TAGS[*]}" )
+          echo "${TAGS[*]}"
       - name: Build image
         id: build_image
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/ubi8-asciidoctor-publish.yaml
+++ b/.github/workflows/ubi8-asciidoctor-publish.yaml
@@ -28,7 +28,7 @@ jobs:
           if [[ "${GITHUB_REF}" =~ refs/tags/(.*) ]]; then
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
-          ( IFS=$','; echo "${TAGS[*]}" )
+          echo "${TAGS[*]}"
       - name: Build image
         id: build_image
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/ubi8-git-publish.yaml
+++ b/.github/workflows/ubi8-git-publish.yaml
@@ -28,7 +28,7 @@ jobs:
           if [[ "${GITHUB_REF}" =~ refs/tags/(.*) ]]; then
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
-          ( IFS=$','; echo "${TAGS[*]}" )
+          echo "${TAGS[*]}"
       - name: Build image
         id: build_image
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/ubi8-google-api-python-client-publish.yaml
+++ b/.github/workflows/ubi8-google-api-python-client-publish.yaml
@@ -28,7 +28,7 @@ jobs:
           if [[ "${GITHUB_REF}" =~ refs/tags/(.*) ]]; then
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
-          ( IFS=$','; echo "${TAGS[*]}" )
+          echo "${TAGS[*]}"
       - name: Build image
         id: build_image
         uses: redhat-actions/buildah-build@v2


### PR DESCRIPTION
#### What is this PR About?
With the switch to `redhat-actions/buildah-build`, it expects the tags to be [separated by space](https://github.com/redhat-actions/buildah-build#action-inputs) rather than a comma.

#### How do we test this?
CI will publish images once merged.

Resolves #474 
cc: @redhat-cop/day-in-the-life
