### PR TITLE
Update Tekton Task image packages to resolve openssl RHSA-2021:1024

### DIFF
--- a/tekton-task-images/conftest/Dockerfile
+++ b/tekton-task-images/conftest/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 RUN microdnf install --assumeyes --nodocs tar gzip && \
+    microdnf update && \
     microdnf clean all 
 
 ADD VERSION /tmp/version
@@ -9,3 +10,5 @@ RUN source /tmp/version && \
     tar -xzf conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz && \
     mv conftest /usr/local/bin/conftest && \
     rm conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz
+
+USER 1001

--- a/tekton-task-images/helm/Dockerfile
+++ b/tekton-task-images/helm/Dockerfile
@@ -2,7 +2,8 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 USER root
 
-RUN microdnf install --assumeyes --nodocs openssl tar gzip && \
+RUN microdnf install --assumeyes --nodocs tar gzip && \
+    microdnf update && \
     microdnf clean all
 
 ADD VERSION /tmp/version


### PR DESCRIPTION
#### What is this PR About?
Will update the openssl version in the [tekton task images](https://quay.io/repository/redhat-cop/tekton-task-conftest/manifest/sha256:21ca8e0b2001610afcae8be481a7a9582fc4366a7cb892f203a83e0ca4f50896?tab=vulnerabilities) to resolve [RHSA-2021:1024](https://access.redhat.com/errata/RHSA-2021:1024)

It will also add a default uid to the conftest image.

#### How do we test this?
```bash
$ podman build -t tekton-task-conftest tekton-task-images/conftest
$ podman run -it --rm tekton-task-conftest bash -c 'rpm -q openssl'
openssl-1.1.1g-15.el8_3.x86_64
```

cc: @redhat-cop/day-in-the-life
