### PR TITLE
Add tower custom buildconfig

### DIFF
--- a/_test/conftest.sh
+++ b/_test/conftest.sh
@@ -196,6 +196,17 @@ setup_file() {
   [ "$status" -eq 0 ]
 }
 
+@test "tower-ocp-custom/.openshift" {
+  tmp=$(split_files "tower-ocp-custom/.openshift")
+
+  namespaces=$(get_rego_namespaces "ocp\.deprecated\.*")
+  cmd="conftest test ${tmp} --output tap ${namespaces}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 0 ]
+}
+
 @test "ubi7-gitlab-runner/.openshift" {
   tmp=$(split_files "ubi7-gitlab-runner/.openshift")
 

--- a/tower-ocp-custom/.applier/group_vars/seed-hosts.yml
+++ b/tower-ocp-custom/.applier/group_vars/seed-hosts.yml
@@ -1,0 +1,25 @@
+---
+tower_ocp_namespace: 'tower-ocp'
+
+tower_ocp_namespace_params:
+  NAMESPACE: '{{ tower_ocp_namespace }}'
+  NAMESPACE_DISPLAY_NAME: 'Tower Namespace'
+  NAMESPACE_DESCRIPTION: 'Ansible Tower and associated resources are deployed to this namespace'
+
+openshift_cluster_content:
+  - object: projectrequest
+    content:
+      - name: 'tower-projects'
+        template: '{{ openshift_templates_raw }}/{{ openshift_templates_raw_version_tag }}/project-requests/create-project.yml'
+        params_from_vars: '{{ tower_ocp_namespace_params }}'
+        action: create
+        tags:
+          - namespaces
+          - tower-ocp
+  - object: tower-ocp
+    content:
+      - name: 'tower-ocp'
+        namespace: '{{ tower_ocp_namespace }}'
+        template: '{{ inventory_dir }}/../files/tower-ocp/tower-ocp-custom-image.yml'
+        tags:
+          - tower-ocp

--- a/tower-ocp-custom/.applier/group_vars/seed-hosts.yml
+++ b/tower-ocp-custom/.applier/group_vars/seed-hosts.yml
@@ -1,5 +1,9 @@
 ---
+
 tower_ocp_namespace: 'tower-ocp'
+
+openshift_templates_raw: "https://raw.githubusercontent.com/redhat-cop/openshift-templates"
+openshift_templates_raw_version_tag: "v1.4.15"
 
 tower_ocp_namespace_params:
   NAMESPACE: '{{ tower_ocp_namespace }}'
@@ -20,6 +24,6 @@ openshift_cluster_content:
     content:
       - name: 'tower-ocp'
         namespace: '{{ tower_ocp_namespace }}'
-        template: '{{ inventory_dir }}/../files/tower-ocp/tower-ocp-custom-image.yml'
+        template: '{{ inventory_dir }}/../.openshift/templates/tower-ocp-custom-image.yml'
         tags:
           - tower-ocp

--- a/tower-ocp-custom/.applier/hosts
+++ b/tower-ocp-custom/.applier/hosts
@@ -1,0 +1,2 @@
+[seed-hosts]
+localhost ansible_connection=local

--- a/tower-ocp-custom/.openshift/templates/tower-ocp-custom-image.yml
+++ b/tower-ocp-custom/.openshift/templates/tower-ocp-custom-image.yml
@@ -37,7 +37,8 @@ objects:
                 boto==2.49.0 \
                 boto3==1.9.200 \
                 awscli==1.16.210 \
-                ansible-tower-cli==3.3.6
+                ansible-tower-cli==3.3.6 \
+                pytz==2021.1
 
           RUN rm -rf /var/cache/yum
           USER awx

--- a/tower-ocp-custom/.openshift/templates/tower-ocp-custom-image.yml
+++ b/tower-ocp-custom/.openshift/templates/tower-ocp-custom-image.yml
@@ -1,0 +1,76 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+labels:
+  template: tower-ocp
+metadata:
+  annotations:
+    description: Custom Ansible Tower builder
+    tags: tower
+  name: tower-ocp
+objects:
+  - apiVersion: build.openshift.io/v1
+    kind: BuildConfig
+    metadata:
+      name: 'tower-ocp'
+    spec:
+      output:
+        to:
+          kind: 'ImageStreamTag'
+          name: 'tower-ocp:${TOWER_IMAGE_VERSION}-custom'
+      source:
+        dockerfile: |
+          FROM ""
+
+          USER root
+          RUN yum install -y \
+                https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+          RUN yum install -y \
+                python-devel \
+                pandoc
+
+          RUN curl --fail -sL https://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_CLIENT_VERSION}/linux/oc.tar.gz | tar -C /usr/local/bin/ -xzf -
+          RUN umask 0022
+          RUN virtualenv /var/lib/awx/venv/ansible
+          RUN /var/lib/awx/venv/ansible/bin/pip install \
+                ansible==2.9.18 \
+                boto==2.49.0 \
+                boto3==1.9.200 \
+                awscli==1.16.210 \
+                ansible-tower-cli==3.3.6
+
+          RUN rm -rf /var/cache/yum
+          USER awx
+
+      strategy:
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: ${TOWER_IMAGE}:${TOWER_IMAGE_VERSION}
+      triggers:
+        - type: ConfigChange
+        - imageChangeParams:
+            automatic: true
+            from:
+              kind: ImageStreamTag
+              name: tower-ocp:${TOWER_IMAGE_VERSION}-custom
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      name: tower-ocp
+    spec:
+      lookupPolicy:
+        local: true
+parameters:
+  - description: Ansible Tower Base Image
+    name: TOWER_IMAGE
+    required: true
+    value: registry.redhat.io/ansible-tower-38/ansible-tower-rhel7
+  - description: Ansible Tower Base Image Version
+    name: TOWER_IMAGE_VERSION
+    required: true
+    value: '3.8.2'
+  - description: Openshift Client Version
+    name: OC_CLIENT_VERSION
+    required: true
+    value: '4.6'

--- a/tower-ocp-custom/README.md
+++ b/tower-ocp-custom/README.md
@@ -1,0 +1,51 @@
+## Notes
+
+The primary use case for this buildconfig and imagestream is to install a custom Ansible Tower image using the official Tower container image as its base.
+
+This example adds several dependencies from pip and a single RPM from EPEL to demonstrate how to load a custom Tower image to your OCP internal image registry.
+
+The official docs which outline how to consume this deploy Ansible Tower with a custom image can be found at:
+
+https://docs.ansible.com/ansible-tower/3.8.2/html/administration/openshift_configuration.html#build-custom-virtual-environments
+
+Note that this has been tested with Ansible Tower 3.8.1 and 3.8.2
+
+The example contains a BuildConfig and ImageStream which shows how you might add dependencies to your Tower container such as pandoc, or a custom Python virtualenv.
+
+Currently this example only has 3 configurable parameters, as shown below:
+
+## Example Parameters
+
+| **Option**   |      **Value**    |  
+|----------|:-------------:|
+| `TOWER_IMAGE` | registry.redhat.io/ansible-tower-38/ansible-tower-rhel7 |
+| `TOWER_IMAGE_VERSION` | 3.8.2 |
+| `OC_CLIENT_VERSION` | 4.6 |
+
+## Prerequisites
+
+The following prerequisites must be met prior to beginning to deploy the Ansible Tower custom image for OCP 4.x
+
+* OpenShift Command Line Tool
+* [Openshift Applier](https://github.com/redhat-cop/openshift-applier/) to deploy custom Ansible Tower base image. As a result you'll need to have [ansible installed](http://docs.ansible.com/ansible/latest/intro_installation.html)
+
+### Environment Setup
+
+1. Clone this repository: `git clone https://github.com/redhat-cop/containers-quickstarts`
+2. `cd containers-quickstarts/tower-ocp-custom`
+3. Run `ansible-galaxy install -r requirements.yml --roles-path=galaxy`
+4. Login to OpenShift: `oc login -u <username> --server=https://api.<example.com>:6443`
+
+### Create the custom Ansible Tower image with Openshift Applier
+
+Run the openshift-applier to create the `tower-ocp` project and deploy required objects
+
+```bash
+ansible-playbook -i ./inventory galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml
+```
+
+### Cleaning up
+
+```bash
+oc delete project tower-ocp
+```

--- a/tower-ocp-custom/README.md
+++ b/tower-ocp-custom/README.md
@@ -41,7 +41,7 @@ The following prerequisites must be met prior to beginning to deploy the Ansible
 Run the openshift-applier to create the `tower-ocp` project and deploy required objects
 
 ```bash
-ansible-playbook -i ./inventory galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml
+ansible-playbook -i ./applier galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml
 ```
 
 ### Cleaning up

--- a/tower-ocp-custom/requirements.yml
+++ b/tower-ocp-custom/requirements.yml
@@ -1,0 +1,9 @@
+# This is the Ansible Galaxy requirements file to pull in the correct roles
+# to support the operation of Ansible Tower provisioning/runs.
+
+# From 'openshift-applier'
+- name: openshift-applier
+  scm: git
+  src: https://github.com/redhat-cop/openshift-applier
+  version: v2.1.2
+


### PR DESCRIPTION
#### What is this PR About?
This quickstart gives an example of how to deploy a custom Ansible Tower image with custom virtualenvs and RPMs directly to your Openshift internal image registry to be consumed by the Ansible Tower 3.8 installer.

#### How do we test this?
Following the steps in the README will yield a buildconfig and an imagestream in your Openshift cluster. Run the applier, and validate:

```bash
$ oc get buildconfig tower-ocp -n tower-ocp
$ oc get imagestream tower-ocp -n tower-ocp
```

cc: @redhat-cop/day-in-the-life
