### PR TITLE
Add dependabot for github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"


### PR DESCRIPTION
#### What is this PR About?
This PR configures Dependabot to also watch GH Actions and allows it to open a PR if we're using old versions of Actions

#### How do we test this?
Nothing to test. After merge, this will begin to watch the repo for out of date actions. This can be seen here: https://github.com/tylerauerbeck/charts-3/pull/1

cc: @redhat-cop/day-in-the-life
