### PR TITLE
BUGFIX: Use openssl to verify Helm checksum

### DIFF
--- a/tekton-task-images/helm/Dockerfile
+++ b/tekton-task-images/helm/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 USER root
 
-RUN microdnf install --assumeyes --nodocs tar gzip && \
+RUN microdnf install --assumeyes --nodocs openssl tar gzip && \
     microdnf update && \
     microdnf clean all
 


### PR DESCRIPTION
#### What is this PR About?
Building this image currently fails because `openssl` isn't installed.
This should also make #496 pass CI tests
```
STEP 5: RUN source /tmp/version &&   curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 &&   chmod 700 get_helm.sh &&   ./get_helm.sh --version ${HELM_VERSION}
In order to verify checksum, openssl must first be installed.
Please install openssl or set VERIFY_CHECKSUM=false in your environment.
Failed to install helm with the arguments provided: --version v3.5.3
Accepted cli arguments are:
	[--help|-h ] ->> prints this help
	[--version|-v <desired_version>] . When not defined it fetches the latest release from GitHub
	e.g. --version v3.0.0 or -v canary
	[--no-sudo]  ->> install without sudo
	For support, go to https://github.com/helm/helm.
error building at STEP "RUN source /tmp/version &&   curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 &&   chmod 700 get_helm.sh &&   ./get_helm.sh --version ${HELM_VERSION}": error while running runtime: exit status 1
level=error msg="exit status 1"
Error: Error: buildah exited with code 1
```

#### How do we test this?
GH PR Action should go :green_heart: 

cc: @redhat-cop/day-in-the-life
