### PR TITLE
Use redhat-actions/push-to-registry for github-runner image

### DIFF
--- a/.github/workflows/github-runner-ubi8.yaml
+++ b/.github/workflows/github-runner-ubi8.yaml
@@ -16,7 +16,7 @@ jobs:
     env:
       CONTEXT_DIR: github-runner-ubi8
       IMAGE_NAME: github-runner-ubi8
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get image tags
@@ -31,14 +31,23 @@ jobs:
           if [[ "${GITHUB_REF}" =~ refs/tags/(.*) ]]; then
               TAGS+=("git-${BASH_REMATCH[1]}")
           fi
-          ( IFS=$','; echo "${TAGS[*]}" )
-      - name: Build and publish image to Quay
-        uses: docker/build-push-action@v1
+          echo "${TAGS[*]}"
+      - name: Build image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
         with:
-          path: ${{ env.CONTEXT_DIR }}
-          registry: quay.io
-          repository: redhat-cop/${{ env.IMAGE_NAME }}
+          context: ${{ env.CONTEXT_DIR }}
+          dockerfiles: |
+            ./${{ env.CONTEXT_DIR }}/Dockerfile
+          image: ${{ env.IMAGE_NAME }}
+          oci: true
+          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+      - name: Publish image to Quay
+        if: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          push: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-          tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+          tags: ${{ steps.build_image.outputs.tags }}


### PR DESCRIPTION
#### What is this PR About?
Switch to https://github.com/redhat-actions/push-to-registry for pushing image to quay.io.
Also switching to `ubuntu-20.04` [per recommendation](https://github.com/redhat-actions/push-to-registry#note-about-github-runners-and-podman).

This should also make #509 obsolete

#### How do we test this?
Should be done by CI :green_heart: 

cc: @redhat-cop/day-in-the-life
