### PR TITLE
Update Jenkins Agent base images to 4.8 + minor improvements

### DIFF
--- a/jenkins-agents/jenkins-agent-ansible/Dockerfile
+++ b/jenkins-agents/jenkins-agent-ansible/Dockerfile
@@ -1,9 +1,9 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 ARG ANSIBLE_VERSION=2.9.13
 
 LABEL \
       release="1" \
-      version="4.7" \
+      version="4.8" \
       architecture="x86_64" \
       io.k8s.display-name="Jenkins Agent Ansible" \
       name="openshift/origin-jenkins-agent-ansible-ubi8" \

--- a/jenkins-agents/jenkins-agent-arachni/Dockerfile
+++ b/jenkins-agents/jenkins-agent-arachni/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 
 ARG VERSION=1.5.1
 ARG WEB_VERSION=0.5.12

--- a/jenkins-agents/jenkins-agent-argocd/Dockerfile
+++ b/jenkins-agents/jenkins-agent-argocd/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 
 ENV ARGOCD_VERSION=2.0.5 \
     YQ_VERSION=v4.11.1

--- a/jenkins-agents/jenkins-agent-conftest/Dockerfile
+++ b/jenkins-agents/jenkins-agent-conftest/Dockerfile
@@ -7,12 +7,11 @@ ARG CONFTEST_VERSION=0.23.0
 
 USER root
 
-RUN curl --fail -skL https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz | tar zxf - -C /usr/local/bin conftest && \
+RUN curl --fail -sL https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz | tar zxf - -C /usr/local/bin conftest && \
     curl --fail -sL  https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz | tar zxf - -C /tmp && \
     ./tmp/bats-core-${BATS_VERSION}/install.sh /usr/local && \
     echo "na na na na na na na na na 🦇👨‍🦰" && \
-    rm -rf /tmp/conftest.tar.gz /tmp/bats* && \
-    chmod -R 775 /usr/local/bin/bats /usr/local/bin/conftest && \
+    rm -rf /tmp/bats* && \
     pip install yq==${YQ_VERSION}
 
 USER 1001

--- a/jenkins-agents/jenkins-agent-cosign/Dockerfile
+++ b/jenkins-agents/jenkins-agent-cosign/Dockerfile
@@ -5,7 +5,7 @@ USER root
 ARG COSIGN_VERSION=1.0.0
 
 # Install cosign
-RUN curl -skL -o /usr/local/bin/cosign https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64 && \
-    chmod -R 775 /usr/local/bin/cosign
+RUN curl -sL -o /usr/local/bin/cosign https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64 && \
+    chmod 755 /usr/local/bin/cosign
 
 USER 1001

--- a/jenkins-agents/jenkins-agent-erlang/Dockerfile
+++ b/jenkins-agents/jenkins-agent-erlang/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 
 ARG ERLANG_VERSION=22.1.4
 ARG REBAR3_VERSION=3.12.0

--- a/jenkins-agents/jenkins-agent-golang/Dockerfile
+++ b/jenkins-agents/jenkins-agent-golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 
 ARG GO_VERSION=1.15.6
 ARG SONAR_SCANNER_VERSION=4.5.0.2216

--- a/jenkins-agents/jenkins-agent-graalvm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-graalvm/Dockerfile
@@ -4,7 +4,7 @@ ENV GRAALVM_HOME=/opt/mandrelJDK
 ENV GRAAL_CE_URL=https://github.com/graalvm/mandrel/releases/download/mandrel-${GRAAL_VERSION}/mandrel-java11-linux-amd64-${GRAAL_VERSION}.tar.gz
 ARG HELM_VERSION=3.6.3
 ARG JQ_VERSION=1.6
-ARG OC_VERSION=4.8.2
+ARG OC_VERSION=4.8
 ARG YQ_VERSION=4.11.2
 
 ADD settings.xml $HOME/.m2/settings.xml
@@ -25,7 +25,8 @@ RUN rm -f /etc/yum.repos.d/*.repo && \
     curl -Lo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq && \
     rm -f /usr/bin/oc && \
-    curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf - && \
+    curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz \
+    | tar zxf - -C /usr/local/bin oc kubectl && \
     ### Cleanup
     dnf clean all && \
     rm -rf /var/cache/yum

--- a/jenkins-agents/jenkins-agent-gradle/Dockerfile
+++ b/jenkins-agents/jenkins-agent-gradle/Dockerfile
@@ -1,9 +1,9 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 
 ENV GRADLE_VERSION=6.3
 ENV GRADLE_USER_HOME=/home/jenkins/.gradle
 
-RUN curl -skL -o /tmp/gradle-bin.zip https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip && \
+RUN curl -sL -o /tmp/gradle-bin.zip https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip && \
     mkdir -p /opt/gradle && \
     unzip -q /tmp/gradle-bin.zip -d /opt/gradle && \
     ln -sf /opt/gradle/gradle-$GRADLE_VERSION/bin/gradle /usr/local/bin/gradle && \

--- a/jenkins-agents/jenkins-agent-helm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-helm/Dockerfile
@@ -3,39 +3,31 @@ FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 ARG VERSION=3.5.2
 ARG YQ_VERSION=v4.5.1
 ARG CT_VERSION=3.3.1
-ARG OPENSHIFT_CLIENT_VERSION=4.7.5
+ARG OPENSHIFT_CLIENT_VERSION=4.8
 ARG CONFTEST_VERSION=0.23.0
 ARG KUBE_LINTER_VERSION=0.2.3
 
 ## Required in order to avoid ct "ascii codec can't encode character" error
-ENV PYTHONIOENCODING=utf-8
+ENV PYTHONIOENCODING=utf-8 \
+    LANG=C.UTF-8 \
+    LANGUAGE=C.UTF-8 \
+    LC_ALL=C.UTF-8
 
 COPY ubi8.repo /tmp/
 
-## Install helm and yq and conftest
-RUN curl -skL -o /tmp/helm.tar.gz https://get.helm.sh/helm-v${VERSION}-linux-amd64.tar.gz && \
-    curl -skL -o /tmp/conftest.tar.gz https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz && \
-    curl -skL -o /tmp/kube-linter.tar.gz https://github.com/stackrox/kube-linter/releases/download/${KUBE_LINTER_VERSION}/kube-linter-linux.tar.gz && \
-    tar -C /tmp -xzf /tmp/helm.tar.gz && \
-    tar -C /tmp -xzf /tmp/conftest.tar.gz && \
-    tar -C /tmp -xzf /tmp/kube-linter.tar.gz && \
-    mv -v /tmp/linux-amd64/helm /tmp/conftest /tmp/kube-linter /usr/local/bin && \
-    chmod -R 775 /usr/local/bin/helm /usr/local/bin/conftest  /usr/local/bin/kube-linter && \
-    rm -rf /tmp/*.tar.gz && \
-    rm -rf /tmp/linux-amd64 && \
+## Install helm, yq, conftest & kube-linter
+RUN curl -sL https://get.helm.sh/helm-v${VERSION}-linux-amd64.tar.gz | tar zxf - -C /usr/local/bin --strip-components=1 linux-amd64/helm && \
+    curl -sL https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz | tar zxf - -C /usr/local/bin conftest && \
+    curl -sL https://github.com/stackrox/kube-linter/releases/download/${KUBE_LINTER_VERSION}/kube-linter-linux.tar.gz | tar zxf - -C /usr/local/bin kube-linter && \
     curl -sL  https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -o /usr/local/bin/yq && \
-    chmod -R 775 /usr/local/bin/yq
+    chmod -R 755 /usr/local/bin/yq
 
 ## Install ct
 RUN curl -sL -o /tmp/chart-testing.tar.gz https://github.com/helm/chart-testing/releases/download/v${CT_VERSION}/chart-testing_${CT_VERSION}_linux_amd64.tar.gz && \
-    mkdir /tmp/chart-testing && \
-    tar -C /tmp/chart-testing -zxf /tmp/chart-testing.tar.gz && \
-    mv /tmp/chart-testing/ct /usr/local/bin && \
-    chmod 775 /usr/local/bin/ct && \
-    rm /tmp/chart-testing.tar.gz && \
     mkdir ${HOME}/.ct && \
-    mv /tmp/chart-testing/etc/chart_schema.yaml /tmp/chart-testing/etc/lintconf.yaml ${HOME}/.ct/ && \
-    rm -rf /tmp/chart-testing
+    tar zxf /tmp/chart-testing.tar.gz -C /usr/local/bin ct && \
+    tar zxf /tmp/chart-testing.tar.gz -C ${HOME}/.ct --strip-components=1 etc && \
+    rm /tmp/chart-testing.tar.gz
 
 ## Install git, python 3.8, yamale, and yamllint
 RUN INSTALL_PKGS="git python38 python38-pip" && \
@@ -48,7 +40,7 @@ RUN INSTALL_PKGS="git python38 python38-pip" && \
     python3 -m pip install yamllint==1.24.1
 
 ## Install oc and kubectl
-RUN curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_CLIENT_VERSION}/openshift-client-linux-${OPENSHIFT_CLIENT_VERSION}.tar.gz \
-    | tar zxf - -C /usr/local/bin oc kubectl 
+RUN curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OPENSHIFT_CLIENT_VERSION}/openshift-client-linux.tar.gz \
+    | tar zxf - -C /usr/local/bin oc kubectl
 
 USER 1001

--- a/jenkins-agents/jenkins-agent-helm/Jenkinsfile.test
+++ b/jenkins-agents/jenkins-agent-helm/Jenkinsfile.test
@@ -7,7 +7,7 @@ pipeline {
         stage ('Run Test') {
             steps {
               sh """
-                  helm help
+                  helm version
                   ct version
                   ls -l ${HOME}/.ct
                   git version
@@ -15,6 +15,7 @@ pipeline {
                   oc version
                   kubectl version
                   conftest --version
+                  yq --version
                   kube-linter version
               """
             }

--- a/jenkins-agents/jenkins-agent-hugo/Dockerfile
+++ b/jenkins-agents/jenkins-agent-hugo/Dockerfile
@@ -1,11 +1,8 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 
 ENV HUGO_VERSION=0.83.1
 
-RUN curl -skL -o /tmp/hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz && \
-    tar -C /tmp -xzf /tmp/hugo.tar.gz && \
-    mv -v /tmp/hugo /usr/local/bin && \
-    chmod -R 775 /usr/local/bin/hugo && \
-    rm -rf /tmp/*.tar.gz
+RUN curl -sL https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz \
+    | tar zxf - -C /usr/local/bin hugo
 
 USER 1001

--- a/jenkins-agents/jenkins-agent-image-mgmt/Dockerfile
+++ b/jenkins-agents/jenkins-agent-image-mgmt/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -L https://github.com/containers/skopeo/archive/v${SKOPEO_VERSION}.tar.
     cd /tmp/skopeo && \
     make binary-local DISABLE_CGO=1
 
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 
 MAINTAINER Andrew Block <ablock@redhat.com>
 

--- a/jenkins-agents/jenkins-agent-mongodb/Dockerfile
+++ b/jenkins-agents/jenkins-agent-mongodb/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 
 USER root
 

--- a/jenkins-agents/jenkins-agent-mvn/Dockerfile
+++ b/jenkins-agents/jenkins-agent-mvn/Dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/openshift/origin-jenkins-agent-maven:4.7
+FROM quay.io/openshift/origin-jenkins-agent-maven:4.8
 ADD settings.xml $HOME/.m2/settings.xml

--- a/jenkins-agents/jenkins-agent-npm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-npm/Dockerfile
@@ -1,15 +1,15 @@
 #invoke npm in jenkinsfile: sh "scl enable rh-nodejs6 'npm run build'"
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 
 ARG JQ_VERSION=1.6
-ARG OC_VERSION=4.6
+ARG OC_VERSION=4.8
 ARG YQ_VERSION=4.6.3
 
 ENV NODEJS_VERSION=12 \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH
 
-RUN curl --silent --location https://rpm.nodesource.com/setup_${NODEJS_VERSION}.x | bash -
+RUN curl -sL https://rpm.nodesource.com/setup_${NODEJS_VERSION}.x | bash -
 
 RUN INSTALL_PKGS="nodejs" && \
     dnf $DISABLE_REPOS install -y --setopt=tsflags=nodocs --disablerepo='rhel-*' \
@@ -26,6 +26,7 @@ RUN INSTALL_PKGS="nodejs" && \
     curl -Lo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq && \
     rm -f /usr/bin/oc && \
-    curl -L http://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz | tar -C /usr/local/bin -xzf -
+    curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz \
+    | tar zxf - -C /usr/local/bin oc kubectl
 
 USER 1001

--- a/jenkins-agents/jenkins-agent-python/Dockerfile
+++ b/jenkins-agents/jenkins-agent-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 
 EXPOSE 8080
 

--- a/jenkins-agents/jenkins-agent-ruby/Dockerfile
+++ b/jenkins-agents/jenkins-agent-ruby/Dockerfile
@@ -1,7 +1,7 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 
 ARG RUBY_VERSION=2.6
-ARG OC_VERSION=4.4
+ARG OC_VERSION=4.8
 
 ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
     DESCRIPTION="Ruby $RUBY_VERSION available as docker container is a base platform for \
@@ -41,8 +41,8 @@ RUN rm -f /etc/yum.repos.d/*.repo && \
     dnf clean all -y && \
     rm -rf /var/cache/dnf
 
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz | tar -C /usr/local/bin -xzf - && \
-    chmod +x /usr/local/bin/oc
+RUN curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz \
+    | tar zxf - -C /usr/local/bin oc kubectl
 
 # Copy extra files to the image.
 COPY ./root/ /

--- a/jenkins-agents/jenkins-agent-rust/Dockerfile
+++ b/jenkins-agents/jenkins-agent-rust/Dockerfile
@@ -1,8 +1,8 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.7
+FROM quay.io/openshift/origin-jenkins-agent-base:4.8
 
 LABEL com.redhat.component="jenkins-agent-rust-ubi7-docker" \
       name="openshift/origin-jenkins-agent-rust-ubi7" \
-      version="4.4" \
+      version="4.8" \
       architecture="x86_64" \
       release="1" \
       io.k8s.display_name="Jenkins Agent Rust" \


### PR DESCRIPTION
#### What is this PR About?
- update Jenkins Agents to use a 4.8 base image
- remove usage of `-k` with `curl` in Jenkins Agent Dockerfiles
- use `curl <url> | tar zxf - -C <path>` pattern to reduce `Dockerfile` size
- Default to use latest stable version of `oc` client (when installed)
 
#### How do we test this?
Should be covered by CI

Can also be tested manually
```bash
./_test/setup.sh applier container-quickstarts-tests pabrahamsson/containers-quickstarts feature/jenkins-agent-4.8-base
./_test/setup.sh test container-quickstarts-tests pabrahamsson/container-quickstarts feature/jenkins-agent-4.8-base
```

cc: @redhat-cop/day-in-the-life
