### PR TITLE
FIX: Add python3-devel to fix ubi8-asciidoctor build

### DIFF
--- a/utilities/ubi8-asciidoctor/Dockerfile
+++ b/utilities/ubi8-asciidoctor/Dockerfile
@@ -33,7 +33,7 @@ USER root
 # including asciidoctor itself
 
 RUN dnf install -y \
-    python3 \
+    python3-devel \
     git \
     ruby \
     make \ 

--- a/utilities/ubi8-asciidoctor/version.json
+++ b/utilities/ubi8-asciidoctor/version.json
@@ -1,1 +1,1 @@
-{"version":"v1.6"}
+{"version":"v1.7"}


### PR DESCRIPTION
#### What is this PR About?
Image [builds](https://github.com/redhat-cop/containers-quickstarts/runs/3625749951?check_suite_focus=true) are failing due to missing `python.h` header file.

#### How do we test this?
```bash
podman build -t ubi8-asciidoctor .
```

cc: @redhat-cop/day-in-the-life
