### PR TITLE
Update skopeo to 1.5.0 in jenkins-agent-image-mgmt

### DIFF
--- a/jenkins-agents/jenkins-agent-image-mgmt/Dockerfile
+++ b/jenkins-agents/jenkins-agent-image-mgmt/Dockerfile
@@ -1,15 +1,17 @@
 FROM registry.access.redhat.com/ubi8/go-toolset:latest as builder
 
-ARG SKOPEO_VERSION=1.1.1
+ARG SKOPEO_VERSION=1.5.0
 
 USER root
 
 RUN curl -L https://github.com/containers/skopeo/archive/v${SKOPEO_VERSION}.tar.gz | tar -C /tmp -zxf - && \
     mv /tmp/skopeo-${SKOPEO_VERSION} /tmp/skopeo && \
     cd /tmp/skopeo && \
-    make binary-local DISABLE_CGO=1
+    make BUILDTAGS=containers_image_openpgp DISABLE_DOCS=1 CGO_ENABLED=0 GO_DYN_FLAGS=
 
 FROM quay.io/openshift/origin-jenkins-agent-base:4.9
+
+ARG OC_VERSION=4.8
 
 MAINTAINER Andrew Block <ablock@redhat.com>
 
@@ -22,9 +24,10 @@ LABEL com.redhat.component="jenkins-agent-image-mgmt" \
 
 USER root
 
-RUN mkdir -p /etc/containers
+RUN mkdir -p /etc/containers && \
+    curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz | tar zxvf - -C /usr/bin oc
 
 COPY --from=builder /tmp/skopeo/default-policy.json /etc/containers/policy.json
-COPY --from=builder /tmp/skopeo/skopeo /usr/bin/
+COPY --from=builder /tmp/skopeo/bin/skopeo /usr/bin/
 
 USER 1001

--- a/jenkins-agents/jenkins-agent-image-mgmt/README.md
+++ b/jenkins-agents/jenkins-agent-image-mgmt/README.md
@@ -1,7 +1,7 @@
 Jenkins Agent for Container and Image Management
 =============================
 
-Jenkins [Agent](https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds) that enables various container and image management capabilities and is optimized for deployment to a Jenkins instance running in the OpenShift Container Platform.
+Jenkins [Agent](https://www.jenkins.io/doc/developer/distributed-builds/) that enables various container and image management capabilities and is optimized for deployment to a Jenkins instance running in the OpenShift Container Platform.
 
 ## Primary Components
 

--- a/jenkins-agents/jenkins-agent-image-mgmt/version.json
+++ b/jenkins-agents/jenkins-agent-image-mgmt/version.json
@@ -1,1 +1,1 @@
-{"version":"v1.0"}
+{"version":"v1.5.0"}


### PR DESCRIPTION
#### What is this PR About?
Bump skopeo to v1.5.0

#### How do we test this?
Should be taken care of by CI, otherwise manually
```
./_test/setup.sh applier pabrahamsson/containers-quickstarts jenkins-agent-image-mgmt-1-5-0
./_test/setup.sh test pabrahamsson/containers-quickstarts jenkins-agent-image-mgmt-1-5-0
```

cc: @redhat-cop/day-in-the-life
