### PR TITLE
Fix broken permissions in Jenkins agents using Python 

### DIFF
--- a/jenkins-agents/jenkins-agent-ansible/Dockerfile
+++ b/jenkins-agents/jenkins-agent-ansible/Dockerfile
@@ -34,7 +34,9 @@ RUN set -x \
      && rm -rf /var/cache/dnf \
      && alternatives --set python3 /usr/bin/python3.8 \
      && python3 -m pip install ${PIP_PKGS} \
-    && echo
+     && chmod -R 775 /etc/alternatives \
+     && chmod -R 775 /var/lib/alternatives \
+     && echo
 
 USER 1001
 ENV \

--- a/jenkins-agents/jenkins-agent-ansible/Jenkinsfile.test
+++ b/jenkins-agents/jenkins-agent-ansible/Jenkinsfile.test
@@ -9,6 +9,7 @@ pipeline {
                 sh """
                     ansible --version
                     molecule --version
+                    java -version
                 """
             }
         }

--- a/jenkins-agents/jenkins-agent-graalvm/Jenkinsfile.test
+++ b/jenkins-agents/jenkins-agent-graalvm/Jenkinsfile.test
@@ -7,7 +7,7 @@ pipeline {
         stage ('Run Test') {
             steps {
               sh """
-                  java --version
+                  java -version
                   mvn --version
                   native-image --version
                   oc version --client

--- a/jenkins-agents/jenkins-agent-helm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-helm/Dockerfile
@@ -37,8 +37,8 @@ RUN INSTALL_PKGS="git python38 python38-pip" && \
     dnf -y clean all && \
     alternatives --set python3 /usr/bin/python3.8 && \
     python3 -m pip install yamale==3.0.1 && \
-    python3 -m pip install yamllint==1.24.1 \
-    chmod -R 775 /var/lib/alternatives \
+    python3 -m pip install yamllint==1.24.1 && \
+    chmod -R 775 /var/lib/alternatives && \
     chmod -R 775 /etc/alternatives
 
 ## Install oc and kubectl

--- a/jenkins-agents/jenkins-agent-helm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-helm/Dockerfile
@@ -37,7 +37,9 @@ RUN INSTALL_PKGS="git python38 python38-pip" && \
     dnf -y clean all && \
     alternatives --set python3 /usr/bin/python3.8 && \
     python3 -m pip install yamale==3.0.1 && \
-    python3 -m pip install yamllint==1.24.1
+    python3 -m pip install yamllint==1.24.1 \
+    chmod -R 775 /var/lib/alternatives \
+    chmod -R 775 /etc/alternatives
 
 ## Install oc and kubectl
 RUN curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OPENSHIFT_CLIENT_VERSION}/openshift-client-linux.tar.gz \

--- a/jenkins-agents/jenkins-agent-helm/Jenkinsfile.test
+++ b/jenkins-agents/jenkins-agent-helm/Jenkinsfile.test
@@ -17,6 +17,7 @@ pipeline {
                   conftest --version
                   yq --version
                   kube-linter version
+                  java -version
               """
             }
         }

--- a/jenkins-agents/jenkins-agent-python/Dockerfile
+++ b/jenkins-agents/jenkins-agent-python/Dockerfile
@@ -22,6 +22,8 @@ RUN INSTALL_PKGS=" \
     dnf -y clean all && \
     alternatives --set python3 /usr/bin/python3.8 && \
     python3 -m pip install --upgrade pip && \
-    python3 -m pip install twine
+    python3 -m pip install twine \
+    chmod -R 775 /var/lib/alternatives \
+    chmod -R 775 /etc/alternatives
 
 USER 1001

--- a/jenkins-agents/jenkins-agent-python/Dockerfile
+++ b/jenkins-agents/jenkins-agent-python/Dockerfile
@@ -22,8 +22,8 @@ RUN INSTALL_PKGS=" \
     dnf -y clean all && \
     alternatives --set python3 /usr/bin/python3.8 && \
     python3 -m pip install --upgrade pip && \
-    python3 -m pip install twine \
-    chmod -R 775 /var/lib/alternatives \
+    python3 -m pip install twine && \
+    chmod -R 775 /var/lib/alternatives && \
     chmod -R 775 /etc/alternatives
 
 USER 1001

--- a/jenkins-agents/jenkins-agent-python/Jenkinsfile.test
+++ b/jenkins-agents/jenkins-agent-python/Jenkinsfile.test
@@ -8,6 +8,7 @@ pipeline {
             steps {
               sh """
                   python -V
+                  java -version
               """
             }
         }

--- a/jenkins-agents/jenkins-agent-python/version.json
+++ b/jenkins-agents/jenkins-agent-python/version.json
@@ -1,1 +1,1 @@
-{"version":"v1.0"}
+{"version":"v1.1"}


### PR DESCRIPTION
#### What is this PR About?
The jenkins-agent-ansible image installs `python38` which through dependencies also updates `chkconfig`. `chkconfig` will update the permissions on `/var/lib/alternatives` and `/etc/alternatives` (`755`), this breaks the `alternatives` command (called as part of the `ENTRYPOINT`).
```
bash-4.4$ /usr/local/bin/run-jnlp-client
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
failed to create /var/lib/alternatives/java.new: Permission denied
```

This PR will "reset" the permissions on `/var/lib/alternatives` and `/etc/alternatives` to the [upstream settings](https://github.com/openshift/jenkins/blob/release-4.8/slave-base/Dockerfile.localdev#L34-L35).

It will also add a test to ensure the `java` executable is in good order.

#### How do we test this?
CI should ensure we now have a working jvm.
Can also test locally:
```
git clone https://github.com/pabrahamsson/containers-quickstarts
cd containers-quickstarts/jenkins-agents/jenkins-agent-ansible
git checkout fix-jenkins-agent-ansible-java
podman build -t jenkins-agent-ansible .
podman run -it --rm -u 1001:0 jenkins-agent-ansible:latest
```
There should be no complaints about permissions on `/var/lib/alternatives/java.new`.

cc: @redhat-cop/day-in-the-life
