### PR TITLE
Update Jenkins Agent base images to 4.9 + add cosign & image-mgmt tests

### DIFF
--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -7,7 +7,7 @@ templates_repo_ref: v1.4.16
 jenkins_agents:
   build:
     ansible:
-      BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-base:4.7
+      BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-base:4.9
       DOCKERFILE_PATH: Dockerfile
       NAME: jenkins-agent-ansible
       SOURCE_CONTEXT_DIR: jenkins-agents/jenkins-agent-ansible
@@ -16,17 +16,17 @@ jenkins_agents:
     arachni: {}
     argocd: {}
     conftest:
-      BUILDER_IMAGE_NAME: quay.io/redhat-cop/jenkins-agent-python:v1.0
+      BUILDER_IMAGE_NAME: quay.io/redhat-cop/jenkins-agent-python:v1.1
+    cosign: {}
     erlang: {}
     golang: {}
-    graalvm:
-      BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-maven:4.7
+    graalvm: {}
     gradle: {}
     helm: {}
     hugo: {}
+    image-mgmt: {}
     mongodb: {}
-    mvn:
-      BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-maven:4.7
+    mvn: {}
     npm: {}
     python: {}
     ruby: {}
@@ -57,6 +57,12 @@ test_pipelines:
     conftest:
       NAME: jenkins-agent-conftest
       PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-conftest
+      PIPELINE_FILENAME: Jenkinsfile.test
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
+    cosign:
+      NAME: jenkins-agent-cosign
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-cosign
       PIPELINE_FILENAME: Jenkinsfile.test
       PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"

--- a/jenkins-agents/jenkins-agent-ansible/Dockerfile
+++ b/jenkins-agents/jenkins-agent-ansible/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 ARG ANSIBLE_VERSION=2.9.13
 
 LABEL \

--- a/jenkins-agents/jenkins-agent-arachni/Dockerfile
+++ b/jenkins-agents/jenkins-agent-arachni/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 ARG VERSION=1.5.1
 ARG WEB_VERSION=0.5.12

--- a/jenkins-agents/jenkins-agent-argocd/Dockerfile
+++ b/jenkins-agents/jenkins-agent-argocd/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 ENV ARGOCD_VERSION=2.0.5 \
     YQ_VERSION=v4.11.1

--- a/jenkins-agents/jenkins-agent-cosign/Dockerfile
+++ b/jenkins-agents/jenkins-agent-cosign/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 USER root
 

--- a/jenkins-agents/jenkins-agent-erlang/Dockerfile
+++ b/jenkins-agents/jenkins-agent-erlang/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 ARG ERLANG_VERSION=22.1.4
 ARG REBAR3_VERSION=3.12.0

--- a/jenkins-agents/jenkins-agent-golang/Dockerfile
+++ b/jenkins-agents/jenkins-agent-golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 ARG GO_VERSION=1.15.6
 ARG SONAR_SCANNER_VERSION=4.5.0.2216

--- a/jenkins-agents/jenkins-agent-graalvm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-graalvm/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-maven:4.8
+FROM quay.io/openshift/origin-jenkins-agent-maven:4.9
 ARG GRAAL_VERSION=20.3.3.0-Final
 ENV GRAALVM_HOME=/opt/mandrelJDK
 ENV GRAAL_CE_URL=https://github.com/graalvm/mandrel/releases/download/mandrel-${GRAAL_VERSION}/mandrel-java11-linux-amd64-${GRAAL_VERSION}.tar.gz

--- a/jenkins-agents/jenkins-agent-gradle/Dockerfile
+++ b/jenkins-agents/jenkins-agent-gradle/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 ENV GRADLE_VERSION=6.3
 ENV GRADLE_USER_HOME=/home/jenkins/.gradle

--- a/jenkins-agents/jenkins-agent-helm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-helm/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 ARG VERSION=3.5.2
 ARG YQ_VERSION=v4.5.1

--- a/jenkins-agents/jenkins-agent-hugo/Dockerfile
+++ b/jenkins-agents/jenkins-agent-hugo/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 ENV HUGO_VERSION=0.83.1
 

--- a/jenkins-agents/jenkins-agent-image-mgmt/Dockerfile
+++ b/jenkins-agents/jenkins-agent-image-mgmt/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -L https://github.com/containers/skopeo/archive/v${SKOPEO_VERSION}.tar.
     cd /tmp/skopeo && \
     make binary-local DISABLE_CGO=1
 
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 MAINTAINER Andrew Block <ablock@redhat.com>
 

--- a/jenkins-agents/jenkins-agent-mongodb/Dockerfile
+++ b/jenkins-agents/jenkins-agent-mongodb/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 USER root
 

--- a/jenkins-agents/jenkins-agent-mvn/Dockerfile
+++ b/jenkins-agents/jenkins-agent-mvn/Dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/openshift/origin-jenkins-agent-maven:4.8
+FROM quay.io/openshift/origin-jenkins-agent-maven:4.9
 ADD settings.xml $HOME/.m2/settings.xml

--- a/jenkins-agents/jenkins-agent-npm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-npm/Dockerfile
@@ -1,5 +1,5 @@
 #invoke npm in jenkinsfile: sh "scl enable rh-nodejs6 'npm run build'"
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 ARG JQ_VERSION=1.6
 ARG OC_VERSION=4.8

--- a/jenkins-agents/jenkins-agent-python/Dockerfile
+++ b/jenkins-agents/jenkins-agent-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 EXPOSE 8080
 

--- a/jenkins-agents/jenkins-agent-ruby/Dockerfile
+++ b/jenkins-agents/jenkins-agent-ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 ARG RUBY_VERSION=2.6
 ARG OC_VERSION=4.8

--- a/jenkins-agents/jenkins-agent-rust/Dockerfile
+++ b/jenkins-agents/jenkins-agent-rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:4.8
+FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 LABEL com.redhat.component="jenkins-agent-rust-ubi7-docker" \
       name="openshift/origin-jenkins-agent-rust-ubi7" \


### PR DESCRIPTION
#### What is this PR About?
Update Jenkins Agent base images to 4.9 where applicable

#### How do we test this?
Will be done by CI or
```
git clone https://github.com/pabrahamsson/containers-quickstarts -b feature/jenkins-agent-4.9-base
cd containers-quickstarts
./_test/setup.sh applier containers-quickstarts-tests pabrahamsson/containers-quickstarts feature/jenkins-agent-4.9-base
./_test/setup.sh test
```

cc: @redhat-cop/day-in-the-life
