### PR TITLE
Feature: ubi8-asciidoctor plantuml support

### DIFF
--- a/utilities/ubi8-asciidoctor/Dockerfile
+++ b/utilities/ubi8-asciidoctor/Dockerfile
@@ -38,6 +38,10 @@ RUN dnf install -y \
     gcc \
     redhat-rpm-config \
     ruby-devel \
+    zlib-devel \
+    libjpeg-turbo-devel \
+    java-11-openjdk-headless \
+    fontconfig \
     && gem install --no-document \
     "asciidoctor:${ASCIIDOCTOR_VERSION}" \
     "asciidoctor-confluence:${ASCIIDOCTOR_CONFLUENCE_VERSION}" \

--- a/utilities/ubi8-asciidoctor/version.json
+++ b/utilities/ubi8-asciidoctor/version.json
@@ -1,1 +1,1 @@
-{"version":"v1.8"}
+{"version":"v1.9"}


### PR DESCRIPTION
#### What is this PR About?
Add openjdk-11 + python dependencies.
This potentially resolves #530 

The following asciidoc seems to generate a proper plantuml diagram
```
[plantuml,jdot,png]
----
!pragma layout smetana
class RedHat
class Fedora
class OpenShift
class Ansible
RedHat <|-- OpenShift
RedHat <|-- Ansible
RedHat <|-- Fedora
----
```
![image](https://user-images.githubusercontent.com/5749047/142682093-5c6c4f4b-2e09-4078-a294-1761fe7f183c.png)



#### How do we test this?
See above

cc: @redhat-cop/day-in-the-life
