### PR TITLE
[Tower Custom Image] Revert addition of helm binary

### DIFF
--- a/tower-ocp-custom/.openshift/templates/tower-ocp-custom-image.yml
+++ b/tower-ocp-custom/.openshift/templates/tower-ocp-custom-image.yml
@@ -27,7 +27,6 @@ objects:
                 https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
           RUN yum install -y \
                 python-devel \
-                helm \
                 pandoc
 
           RUN curl --fail -sL https://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_CLIENT_VERSION}/linux/oc.tar.gz | tar -C /usr/local/bin/ -xzf -


### PR DESCRIPTION
This PR reverts the helm installation added for Tower image template,  applied in https://github.com/redhat-cop/containers-quickstarts/pull/549 , which was not needed and was applied by mistake

#### What is this PR About?
Removal of helm binary installation in custom Tower image template

#### How do we test this?
Run the Tower image build and confirm helm is not installed during the build.

cc: @redhat-cop/day-in-the-life
