### PR TITLE
Switch to Ruby 2.7 in jenkins-agent-ruby image

### DIFF
--- a/jenkins-agents/jenkins-agent-ruby/Dockerfile
+++ b/jenkins-agents/jenkins-agent-ruby/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
-ARG RUBY_VERSION=2.6
-ARG OC_VERSION=4.8
+ARG RUBY_VERSION=2.7
+ARG OC_VERSION=4.9
 
 ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
     DESCRIPTION="Ruby $RUBY_VERSION available as docker container is a base platform for \


### PR DESCRIPTION
#### What is this PR About?
Ruby 2.6 is nearing [EOL (March 2022)](https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/)
> Ruby 2.6 is now under the state of the security maintenance phase, until the end of March of 2022. After that date, maintenance of Ruby 2.6 will be ended. We recommend you start planning the migration to newer versions of Ruby, such as 3.0 or 2.7.

#### How do we test this?
CI will pass

cc: @redhat-cop/day-in-the-life
