### PR TITLE
added ghcr to publish ci and remove branch filtering to always publish on push

### DIFF
--- a/.github/workflows/build-s2i-python-kopf-publish.yaml
+++ b/.github/workflows/build-s2i-python-kopf-publish.yaml
@@ -2,8 +2,6 @@
 name: build-s2i-python-kopf-publish
 on:
   push:
-    branches:
-      - master
     paths:
       - build-s2i-python-kopf/version.json
       - .github/workflows/build-s2i-python-kopf-publish.yaml
@@ -12,6 +10,7 @@ jobs:
     env:
       CONTEXT_DIR: build-s2i-python-kopf
       IMAGE_NAME: python-kopf-s2i
+      REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -33,7 +32,18 @@ jobs:
             ./${{ env.CONTEXT_DIR }}/Dockerfile
           image: ${{ env.IMAGE_NAME }}
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+
+      - name: Push to ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ghcr.io/${{ github.repository }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${{ steps.build_image.outputs.tags }}
+
       - name: Push to Quay
+        if: ${{ env.REGISTRY }} != ""
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/jenkins-agent-image-mgmt-publish.yaml
+++ b/.github/workflows/jenkins-agent-image-mgmt-publish.yaml
@@ -1,10 +1,6 @@
 name: jenkins-agent-image-mgmt-publish
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
     paths:
       - jenkins-agents/jenkins-agent-image-mgmt/version.json
       - .github/workflows/jenkins-agent-image-mgmt-publish.yaml
@@ -13,6 +9,7 @@ jobs:
     env:
       context: jenkins-agents/jenkins-agent-image-mgmt
       image_name: jenkins-agent-image-mgmt
+      REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -38,7 +35,18 @@ jobs:
             ./${{ env.context }}/Dockerfile
           image: ${{ env.image_name }}
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+
+      - name: Push to ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ghcr.io/${{ github.repository }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${{ steps.build_image.outputs.tags }}
+
       - name: Push to Quay
+        if: ${{ env.REGISTRY }} != ""
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/jenkins-agent-python-publish.yaml
+++ b/.github/workflows/jenkins-agent-python-publish.yaml
@@ -1,10 +1,6 @@
 name: jenkins-agent-python-publish
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
     paths:
       - jenkins-agents/jenkins-agent-python/version.json
       - .github/workflows/jenkins-agent-python-publish.yaml
@@ -13,6 +9,7 @@ jobs:
     env:
       context: jenkins-agents/jenkins-agent-python
       image_name: jenkins-agent-python
+      REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -38,7 +35,18 @@ jobs:
             ./${{ env.context }}/Dockerfile
           image: ${{ env.image_name }}
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+
+      - name: Push to ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ghcr.io/${{ github.repository }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${{ steps.build_image.outputs.tags }}
+
       - name: Push to Quay
+        if: ${{ env.REGISTRY }} != ""
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/rabbitmq-publish.yaml
+++ b/.github/workflows/rabbitmq-publish.yaml
@@ -1,10 +1,6 @@
 name: rabbitmq-publish
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
     paths:
       - rabbitmq/version.json
       - .github/workflows/rabbitmq-publish.yaml
@@ -13,6 +9,7 @@ jobs:
     env:
       context: rabbitmq
       image_name: rabbitmq
+      REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -38,7 +35,18 @@ jobs:
             ./${{ env.context }}/Dockerfile
           image: ${{ env.image_name }}
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+
+      - name: Push to ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ghcr.io/${{ github.repository }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${{ steps.build_image.outputs.tags }}
+
       - name: Push to Quay
+        if: ${{ env.REGISTRY }} != ""
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/tekton-task-images-conftest-publish.yaml
+++ b/.github/workflows/tekton-task-images-conftest-publish.yaml
@@ -1,10 +1,6 @@
 name: tekton-task-images-conftest-publish
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
     paths:
       - tekton-task-images/conftest/VERSION
       - .github/workflows/tekton-task-images-conftest-publish.yaml
@@ -13,6 +9,7 @@ jobs:
     env:
       context: tekton-task-images/conftest
       image_name: tekton-task-conftest
+      REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -36,7 +33,18 @@ jobs:
             ./${{ env.context }}/Dockerfile
           image: ${{ env.image_name }}
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+
+      - name: Push to ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ghcr.io/${{ github.repository }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${{ steps.build_image.outputs.tags }}
+
       - name: Push to Quay
+        if: ${{ env.REGISTRY }} != ""
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/tekton-task-images-helm-publish.yaml
+++ b/.github/workflows/tekton-task-images-helm-publish.yaml
@@ -1,10 +1,6 @@
 name: tekton-task-images-helm-publish
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
     paths:
       - tekton-task-images/helm/VERSION
       - .github/workflows/tekton-task-images-helm-publish.yaml
@@ -13,6 +9,7 @@ jobs:
     env:
       context: tekton-task-images/helm
       image_name: tekton-task-helm
+      REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -36,7 +33,18 @@ jobs:
             ./${{ env.context }}/Dockerfile
           image: ${{ env.image_name }}
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+
+      - name: Push to ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ghcr.io/${{ github.repository }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${{ steps.build_image.outputs.tags }}
+
       - name: Push to Quay
+        if: ${{ env.REGISTRY }} != ""
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/ubi7-gitlab-runner-publish.yaml
+++ b/.github/workflows/ubi7-gitlab-runner-publish.yaml
@@ -1,10 +1,6 @@
 name: ubi7-gitlab-runner-publish
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
     paths:
       - ubi7-gitlab-runner/version.json
       - .github/workflows/ubi7-gitlab-runner-publish.yaml
@@ -13,6 +9,7 @@ jobs:
     env:
       context: ubi7-gitlab-runner
       image_name: ubi7-gitlab-runner
+      REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -38,7 +35,18 @@ jobs:
             ./${{ env.context }}/Dockerfile
           image: ${{ env.image_name }}
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+
+      - name: Push to ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ghcr.io/${{ github.repository }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${{ steps.build_image.outputs.tags }}
+
       - name: Push to Quay
+        if: ${{ env.REGISTRY }} != ""
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/ubi8-asciidoctor-publish.yaml
+++ b/.github/workflows/ubi8-asciidoctor-publish.yaml
@@ -1,10 +1,6 @@
 name: ubi8-asciidoctor-publish
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
     paths:
       - utilities/ubi8-asciidoctor/version.json
       - .github/workflows/ubi8-asciidoctor-publish.yaml
@@ -13,6 +9,7 @@ jobs:
     env:
       context: utilities/ubi8-asciidoctor
       image_name: ubi8-asciidoctor
+      REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -38,7 +35,18 @@ jobs:
             ./${{ env.context }}/Dockerfile
           image: ${{ env.image_name }}
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+
+      - name: Push to ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ghcr.io/${{ github.repository }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${{ steps.build_image.outputs.tags }}
+
       - name: Push to Quay
+        if: ${{ env.REGISTRY }} != ""
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/ubi8-bats-publish.yaml
+++ b/.github/workflows/ubi8-bats-publish.yaml
@@ -1,10 +1,6 @@
 name: ubi8-bats-publish
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
     paths:
       - utilities/ubi8-bats/version.json
       - .github/workflows/ubi8-bats-publish.yaml
@@ -13,6 +9,7 @@ jobs:
     env:
       context: utilities/ubi8-bats
       image_name: ubi8-bats
+      REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -38,7 +35,18 @@ jobs:
             ./${{ env.context }}/Dockerfile
           image: ${{ env.image_name }}
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+
+      - name: Push to ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ghcr.io/${{ github.repository }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${{ steps.build_image.outputs.tags }}
+
       - name: Push to Quay
+        if: ${{ env.REGISTRY }} != ""
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/ubi8-git-publish.yaml
+++ b/.github/workflows/ubi8-git-publish.yaml
@@ -1,10 +1,6 @@
 name: ubi8-git-publish
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
     paths:
       - utilities/ubi8-git/version.json
       - .github/workflows/ubi8-git-publish.yaml
@@ -13,6 +9,7 @@ jobs:
     env:
       context: utilities/ubi8-git
       image_name: ubi8-git
+      REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -38,7 +35,18 @@ jobs:
             ./${{ env.context }}/Dockerfile
           image: ${{ env.image_name }}
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+
+      - name: Push to ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ghcr.io/${{ github.repository }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${{ steps.build_image.outputs.tags }}
+
       - name: Push to Quay
+        if: ${{ env.REGISTRY }} != ""
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/ubi8-google-api-python-client-publish.yaml
+++ b/.github/workflows/ubi8-google-api-python-client-publish.yaml
@@ -1,10 +1,6 @@
 name: ubi8-google-api-python-client-publish
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
     paths:
       - utilities/ubi8-google-api-python-client/version.json
       - .github/workflows/ubi8-google-api-python-client-publish.yaml
@@ -13,6 +9,7 @@ jobs:
     env:
       context: utilities/ubi8-google-api-python-client
       image_name: ubi8-google-api-python-client
+      REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -38,7 +35,18 @@ jobs:
             ./${{ env.context }}/Dockerfile
           image: ${{ env.image_name }}
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
+
+      - name: Push to ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          registry: ghcr.io/${{ github.repository }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${{ steps.build_image.outputs.tags }}
+
       - name: Push to Quay
+        if: ${{ env.REGISTRY }} != ""
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:


### PR DESCRIPTION
#### What is this PR About?
Reason/concept behind this change: when building on my fork, as the actions are only active on master, I never know if my changes have worked as I normally work on a dedicated branch for that change. this change removes those filters for that reason.

also, as we push to quay, my fork needs to have quay config setup. i have this already, but 99% of people wont. so I've added ghcr in so they can run the publish

#### How do we test this?
CI goes green on merge. you can see it green on my fork: https://github.com/garethahealy/containers-quickstarts/actions

cc: @redhat-cop/day-in-the-life
