### PR TITLE
FIX: Avoid Docker Hub rate limit for Zap Agent

### DIFF
--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -31,8 +31,7 @@ jenkins_agents:
     python: {}
     ruby: {}
     rust: {}
-    zap:
-      BUILDER_IMAGE_NAME: centos:centos7
+    zap: {}
 
 test_pipelines:
   deploy:

--- a/jenkins-agents/jenkins-agent-zap/Dockerfile
+++ b/jenkins-agents/jenkins-agent-zap/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM quay.io/centos/centos:centos7
 LABEL maintainer="Deven Phillips <deven.phillips@redhat.com>"
 
 ARG ZAPROXY_VERSION="2.9.0"


### PR DESCRIPTION
#### What is this PR About?
It will fix the issue below
```
Pulling image centos:centos7 ...
Trying to pull docker.io/library/centos:centos7...
time="2022-03-01T23:25:13Z" level=warning msg="failed, retrying in 1s ... (1/3). Error: initializing source docker://centos:centos7: reading manifest centos7 in docker.io/library/centos: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"
time="2022-03-01T23:25:49Z" level=warning msg="failed, retrying in 2s ... (2/3). Error: initializing source docker://centos:centos7: reading manifest centos7 in docker.io/library/centos: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"
time="2022-03-01T23:26:35Z" level=warning msg="failed, retrying in 4s ... (3/3). Error: determining manifest MIME type for docker://centos:centos7: reading manifest sha256:dead07b4d8ed7e29e98de0f4504d87e8880d4347859d839686a31da35a3b532f in docker.io/library/centos: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"
Warning: Pull failed, retrying in 5s ...
```

#### How do we test this?
CI job should pass

cc: @redhat-cop/day-in-the-life
