### PR TITLE
Bump Jenkins agent Python version to 3.9

### DIFF
--- a/jenkins-agents/jenkins-agent-python/Dockerfile
+++ b/jenkins-agents/jenkins-agent-python/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 EXPOSE 8080
 
-ENV PYTHON_VERSION=3.8 \
+ENV PYTHON_VERSION=3.9 \
     PATH=$HOME/.local/bin/:$PATH \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING=UTF-8 \
@@ -13,14 +13,14 @@ ENV PYTHON_VERSION=3.8 \
 ADD ubi8.repo /tmp/ubi8.repo
 
 RUN INSTALL_PKGS=" \
-      python38 python38-devel nss_wrapper httpd httpd-devel mod_ssl mod_ldap \
+      python39 python39-devel nss_wrapper httpd httpd-devel mod_ssl mod_ldap \
       mod_session atlas-devel gcc-gfortran libffi-devel libtool-ltdl enchant" && \
     rm -f /etc/yum.repos.d/*.repo && \
     mv /tmp/ubi8.repo /etc/yum.repos.d && \
     dnf -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf -y clean all && \
-    alternatives --set python3 /usr/bin/python3.8 && \
+    alternatives --set python3 /usr/bin/python3.9 && \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install twine && \
     chmod -R 775 /var/lib/alternatives && \


### PR DESCRIPTION
#### What is this PR About?
This PR is for bumping the version of Python to 3.9, which is the latest supported version so far by Red Hat.

#### How do we test this?
We have been using this in our Red Hat Training organization for some time.
I believe this repo has automation to test this as well. If not, further recommendations will be made.

cc: @redhat-cop/day-in-the-life
