### PR TITLE
Disable global GIT SSL verification on jenkins slaves: npm and mvn

### DIFF
--- a/jenkins-agents/jenkins-agent-mvn/Dockerfile
+++ b/jenkins-agents/jenkins-agent-mvn/Dockerfile
@@ -1,2 +1,3 @@
 FROM quay.io/openshift/origin-jenkins-agent-maven:4.9
+RUN git config --global http.sslVerify false
 ADD settings.xml $HOME/.m2/settings.xml

--- a/jenkins-agents/jenkins-agent-npm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-npm/Dockerfile
@@ -25,7 +25,8 @@ RUN INSTALL_PKGS="nodejs" && \
     curl -Lo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq && \
     rm -f /usr/bin/oc && \
-    curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz \
+    curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz && \
+    git config --global http.sslVerify false && \
     | tar zxf - -C /usr/local/bin oc kubectl
 
 USER 1001


### PR DESCRIPTION
#### What is this PR About?
This PR sets global SSL verfication for git to be disabled.

#### How do we test this?
Provide commands/steps to test this PR.

cc: @redhat-cop/day-in-the-life
