### PR TITLE
Update cosign from v1.0.0 to v1.7.2 on jenkins-agent-cosign

### DIFF
--- a/jenkins-agents/jenkins-agent-cosign/Dockerfile
+++ b/jenkins-agents/jenkins-agent-cosign/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/openshift/origin-jenkins-agent-base:4.9
 
 USER root
 
-ARG COSIGN_VERSION=1.0.0
+ARG COSIGN_VERSION=1.7.2
 
 # Install cosign
 RUN curl -sL -o /usr/local/bin/cosign https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64 && \


### PR DESCRIPTION
#### What is this PR About?
This PR updates jenkins-agent-cosign Dockerfile to install v1.7.2 version of cosign instead of v1.0.0

#### How do we test this?
Build&Run the image with TL500 exercise

cc: @redhat-cop/day-in-the-life
