### PR TITLE
Update to current versions - housekeeping

### DIFF
--- a/utilities/ubi8-asciidoctor/Dockerfile
+++ b/utilities/ubi8-asciidoctor/Dockerfile
@@ -3,17 +3,17 @@ FROM registry.access.redhat.com/ubi8:latest
 LABEL MAINTAINERS="Red Hat Services"
 
 ARG ARCH=amd64
-ARG RUBY_VERSION=3.0
-ARG asciidoctor_version=2.0.18
+ARG RUBY_VERSION=3.1
+ARG asciidoctor_version=2.0.20
 ARG asciidoctor_confluence_version=0.0.2
-ARG asciidoctor_pdf_version=2.3.4
-ARG asciidoctor_diagram_version=2.2.3
+ARG asciidoctor_pdf_version=2.3.9
+ARG asciidoctor_diagram_version=2.2.14
 ARG asciidoctor_epub3_version=1.5.1
 ARG asciidoctor_mathematical_version=0.3.5
-ARG asciidoctor_revealjs_version=4.1.0
+ARG asciidoctor_revealjs_version=5.0.1
 ARG kramdown_asciidoc_version=2.1.0
 ARG asciidoctor_bibtex_version=0.8.0
-ARG pandoc_version=3.0
+ARG pandoc_version=3.1.8
 ARG asciidoctor_reducer_version=1.0.2
 ARG epubcheck_ruby_version=4.2.6.0
 

--- a/utilities/ubi8-asciidoctor/version.json
+++ b/utilities/ubi8-asciidoctor/version.json
@@ -1,1 +1,1 @@
-{"version":"v2.1"}
+{"version":"v2.1.0"}

--- a/utilities/ubi8-asciidoctor/version.json
+++ b/utilities/ubi8-asciidoctor/version.json
@@ -1,1 +1,1 @@
-{"version":"v2.0.1"}
+{"version":"v2.1"}


### PR DESCRIPTION
#### What is this PR About?
Describe the contents of the PR
Versions of dependencies updates
asciidoctor 2.0.18 -> 2.0.20
asciidoctor-pdf 2.3.4 -> 2.39
asciidoctor-diagram 2.2.3 -> 2.2.14
asciidoctor_revealjs 4.1.0 -> 5.0.1
pandoc 3.0 -> 3.1.8
ruby 3.0 -> 3.1

version of image 2.0.1 -> 2.1

#### How do we test this?
Provide commands/steps to test this PR.
Create the image.
Generate a pdf.
Compare with previous generated pdf, from previous image version.
Tested this version with older generated pdf.
pdf is generated and comparable with previous version
There are differences, but that depends on the style-sheet used by user, which is not under control of this image.

cc: @redhat-cop/day-in-the-life
