### PR TITLE
updated tekton versions to be renovated

### DIFF
--- a/.github/workflows/tekton-task-images-conftest-pr.yaml
+++ b/.github/workflows/tekton-task-images-conftest-pr.yaml
@@ -4,6 +4,10 @@ on:
     paths:
       - tekton-task-images/conftest/**
       - .github/workflows/tekton-task-images-conftest-pr.yaml
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     env:
@@ -15,7 +19,7 @@ jobs:
 
       - name: Convert VERSION to version.json
         run: |
-          version=$(cat ${{ env.context }}/VERSION | cut -d"=" -f2)
+          version=$(sed -n '2p' ${{ env.context }}/VERSION | cut -d"=" -f2)
           jq -c --null-input --arg version "v$version" '{ "version": $version }' > ${{ env.context }}/version.json
 
       - name: Check and verify version.json
@@ -33,6 +37,7 @@ jobs:
           image: ${{ env.image_name }}
           oci: true
           tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
+
       - name: Test image
         run: |
           echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.VERSION }} conftest version"

--- a/.github/workflows/tekton-task-images-conftest-publish.yaml
+++ b/.github/workflows/tekton-task-images-conftest-publish.yaml
@@ -4,6 +4,10 @@ on:
     paths:
       - tekton-task-images/conftest/VERSION
       - .github/workflows/tekton-task-images-conftest-publish.yaml
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     env:
@@ -11,12 +15,14 @@ jobs:
       image_name: tekton-task-conftest
       REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Convert VERSION to version.json
         run: |
-          version=$(cat ${{ env.context }}/VERSION | cut -d"=" -f2)
+          version=$(sed -n '2p' ${{ env.context }}/VERSION | cut -d"=" -f2)
           jq -c --null-input --arg version "v$version" '{ "version": $version }' > ${{ env.context }}/version.json
 
       - name: Get image tags

--- a/.github/workflows/tekton-task-images-helm-pr.yaml
+++ b/.github/workflows/tekton-task-images-helm-pr.yaml
@@ -4,6 +4,10 @@ on:
     paths:
       - tekton-task-images/helm/**
       - .github/workflows/tekton-task-images-helm-pr.yaml
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     env:
@@ -33,6 +37,7 @@ jobs:
           image: ${{ env.image_name }}
           oci: true
           tags: ${{ steps.check_version.outputs.IMAGE_TAGS }}
+
       - name: Test image contains the version of the binary
         run: |
           echo "Running: podman run ${image_name}:${{ steps.check_version.outputs.VERSION }} helm version"

--- a/.github/workflows/tekton-task-images-helm-pr.yaml
+++ b/.github/workflows/tekton-task-images-helm-pr.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Convert VERSION to version.json
         run: |
-          version=$(cat ${{ env.context }}/VERSION | cut -d"=" -f2)
+          version=$(sed -n '2p' ${{ env.context }}/VERSION | cut -d"=" -f2)
           jq -c --null-input --arg version "v$version" '{ "version": $version }' > ${{ env.context }}/version.json
 
       - name: Check and verify version.json

--- a/.github/workflows/tekton-task-images-helm-publish.yaml
+++ b/.github/workflows/tekton-task-images-helm-publish.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Convert VERSION to version.json
         run: |
-          version=$(cat ${{ env.context }}/VERSION | cut -d"=" -f2)
+          version=$(sed -n '2p' ${{ env.context }}/VERSION | cut -d"=" -f2)
           jq -c --null-input --arg version "v$version" '{ "version": $version }' > ${{ env.context }}/version.json
 
       - name: Get image tags

--- a/.github/workflows/tekton-task-images-helm-publish.yaml
+++ b/.github/workflows/tekton-task-images-helm-publish.yaml
@@ -4,6 +4,10 @@ on:
     paths:
       - tekton-task-images/helm/VERSION
       - .github/workflows/tekton-task-images-helm-publish.yaml
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     env:
@@ -11,6 +15,8 @@ jobs:
       image_name: tekton-task-helm
       REGISTRY: ${{ secrets.REGISTRY_URI }}
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest version is supported.
+
+## Reporting a Vulnerability
+
+For any issues or concerns, please contact: [@container-cop-core](https://github.com/orgs/redhat-cop/teams/container-cop-core)

--- a/renovate.json
+++ b/renovate.json
@@ -26,5 +26,16 @@
     "**/tower-ocp-custom/**",
     "**/ubi7-gitlab-runner/**",
     "**/zalenium/**"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^.+\\/VERSION$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION=(?<currentValue>.+?)?\\s"
+      ]
+    }
   ]
 }

--- a/tekton-task-images/conftest/VERSION
+++ b/tekton-task-images/conftest/VERSION
@@ -1,1 +1,2 @@
+# renovate: datasource=github-releases depName=open-policy-agent/conftest
 CONFTEST_VERSION=0.41.0

--- a/tekton-task-images/helm/Dockerfile
+++ b/tekton-task-images/helm/Dockerfile
@@ -2,6 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3-1361.1699548032@sha256:c777
 
 USER root
 
+# renovate: datasource=github-releases depName=mikefarah/yq
 ARG YQ_VERSION=4.23.1
 
 RUN microdnf install -y --nodocs openssl tar git findutils gzip && \

--- a/tekton-task-images/helm/VERSION
+++ b/tekton-task-images/helm/VERSION
@@ -1,1 +1,2 @@
+# renovate: datasource=github-releases depName=helm/helm
 HELM_VERSION=3.11.2


### PR DESCRIPTION
- added renovate to tekton images
- added default permissions for CI to be read-only, and elevated where needed - https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

cc: @redhat-cop/day-in-the-life
