### PR TITLE
fix: Remove version testing for ubi8-bats dependencies

### DIFF
--- a/utilities/ubi8-bats/test/unit.bats
+++ b/utilities/ubi8-bats/test/unit.bats
@@ -3,29 +3,24 @@
 @test "bats: version" {
   run bats --version
   [ "${status}" -eq 0 ]
-  [ "${lines[0]}" = "Bats 1.10.0" ]
 }
 
 @test "helm: version" {
   run helm version
   [ "${status}" -eq 0 ]
-  [[ "${lines[0]}" =~ v3.11.3 ]]
 }
 
 @test "jq: version" {
   run jq --version
   [ "${status}" -eq 0 ]
-  [ "${lines[0]}" = "jq-1.6" ]
 }
 
 @test "oc: version" {
-  run oc version
+  run oc version --client
   [ "${status}" -eq 0 ]
-  [[ "${lines[0]}" =~ 4.14.3 ]]
 }
 
 @test "yq: version" {
   run yq --version
   [ "${status}" -eq 0 ]
-  [ "${lines[0]}" = "yq (https://github.com/mikefarah/yq/) version v4.40.5" ]
 }


### PR DESCRIPTION
#### What is this PR About?
Remove the need to test hard coded versions of ubi8-bats dependencies. It is enough to test that the dependency is able to execute successfully.

#### How do we test this?
CI goes :heavy_check_mark: 

cc: @redhat-cop/day-in-the-life
