### PR TITLE
🫥 chown fix for npm error 🫥

### DIFF
--- a/jenkins-agents/jenkins-agent-npm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-npm/Dockerfile
@@ -36,7 +36,7 @@ RUN dnf module enable -y nodejs:${NODEJS_VERSION} && \
     dnf clean all && \
     npm install -g /tmp
 
-RUN chown -R 1001:0 "/home/jenkins/.npm" \
+RUN chown -R 1001:0 "/home/jenkins/.npm" && \
     chmod -R 775 "/home/jenkins/.npm"
 
 COPY --from=builder /usr/local/bin/yq /usr/local/bin/yq

--- a/jenkins-agents/jenkins-agent-npm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-npm/Dockerfile
@@ -36,6 +36,8 @@ RUN dnf module enable -y nodejs:${NODEJS_VERSION} && \
     dnf clean all && \
     npm install -g /tmp
 
+RUN chown -R 1001:0 "/home/jenkins/.npm"
+
 COPY --from=builder /usr/local/bin/yq /usr/local/bin/yq
 COPY --from=builder /usr/local/bin/jq /usr/local/bin/jq
 

--- a/jenkins-agents/jenkins-agent-npm/Dockerfile
+++ b/jenkins-agents/jenkins-agent-npm/Dockerfile
@@ -36,7 +36,8 @@ RUN dnf module enable -y nodejs:${NODEJS_VERSION} && \
     dnf clean all && \
     npm install -g /tmp
 
-RUN chown -R 1001:0 "/home/jenkins/.npm"
+RUN chown -R 1001:0 "/home/jenkins/.npm" \
+    chmod -R 775 "/home/jenkins/.npm"
 
 COPY --from=builder /usr/local/bin/yq /usr/local/bin/yq
 COPY --from=builder /usr/local/bin/jq /usr/local/bin/jq


### PR DESCRIPTION
#### What is this PR About?

NPM builds get below error while using this agent: 

npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /home/jenkins/.npm/_cacache
npm ERR! errno -13
npm ERR! 
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! 
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1000790000:0 "/home/jenkins/.npm"


#### How do we test this?
Adding the step that npm suggests in the above error

cc: @redhat-cop/day-in-the-life
